### PR TITLE
[EIS-62] kconfig: defaults: disable `MBEDTLS_ZEPHYR_ENTROPY`

### DIFF
--- a/Kconfig.defaults.core
+++ b/Kconfig.defaults.core
@@ -50,7 +50,7 @@ configdefault MBEDTLS_PSA_CRYPTO_C
 configdefault MBEDTLS_ENTROPY_ENABLED
 	default y
 configdefault MBEDTLS_ZEPHYR_ENTROPY
-	default y
+	default y if !NRF_CC3XX_PLATFORM
 # Key derivation
 configdefault MBEDTLS_HKDF_C
 	default y


### PR DESCRIPTION
Disable `MBEDTLS_ZEPHYR_ENTROPY` when using the `NRF_CC3XX_PLATFORM` library, as it has its own internal implementation of `mbedtls_hardware_poll` that we don't want to override.