### PR TITLE
common_boot: initialise USB

### DIFF
--- a/apps/gateway_usb/src/main.c
+++ b/apps/gateway_usb/src/main.c
@@ -10,7 +10,6 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/usb/usb_device.h>
 
 #include <infuse/epacket/interface.h>
 #include <infuse/epacket/packet.h>
@@ -21,13 +20,8 @@ int main(void)
 {
 	const struct device *epacket_usb = DEVICE_DT_GET(DT_NODELABEL(epacket_usb));
 	struct net_buf *buf;
-	int ret, cnt = 0;
+	int cnt = 0;
 	uint8_t auth;
-
-	ret = usb_enable(NULL);
-	if (ret != 0) {
-		LOG_ERR("usb enable error %d", ret);
-	}
 
 	for (;;) {
 		buf = epacket_alloc_tx_for_interface(epacket_usb, K_FOREVER);
@@ -38,7 +32,7 @@ int main(void)
 
 		epacket_set_tx_metadata(buf, auth, 0x12, 0xF0);
 		epacket_queue(epacket_usb, buf);
-		LOG_INF("Sent %s %d %d", epacket_usb->name, ret, cnt++);
+		LOG_INF("Sent %s %d", epacket_usb->name, cnt++);
 		k_sleep(K_SECONDS(1));
 	}
 	return 0;

--- a/lib/common_boot.c
+++ b/lib/common_boot.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/usb/usb_device.h>
 
 #include <infuse/identifiers.h>
 #include <infuse/fs/kv_store.h>
@@ -38,6 +39,13 @@ static int infuse_common_boot(void)
 		}
 	}
 #endif /* CONFIG_KV_STORE */
+
+#ifdef CONFIG_USB_DEVICE_STACK
+	rc = usb_enable(NULL);
+	if (rc != 0) {
+		LOG_ERR("USB enable error (%d)", rc);
+	}
+#endif /* CONFIG_USB_DEVICE_STACK */
 
 	LOG_INF("\t Device: %016llx", device_id);
 	LOG_INF("\t  Board: %s", CONFIG_BOARD);


### PR DESCRIPTION
Initialise the USB stack in `common_boot` if it is enabled.