### PR TITLE
tdf: move state to be first argument

### DIFF
--- a/include/infuse/tdf/tdf.h
+++ b/include/infuse/tdf/tdf.h
@@ -79,19 +79,19 @@ static inline void tdf_buffer_state_reset(struct tdf_buffer_state *state)
 /**
  * @brief Add TDFs to memory buffer
  *
+ * @param state Pointer to current buffer state
  * @param tdf_id TDF sensor ID
  * @param tdf_len Length of a single TDF
  * @param tdf_num Number of TDFs to try to add
  * @param time Civil time associated with the first TDF. 0 for no timestamp.
  * @param period Civil time between tdfs when @a tdf_num > 0.
- * @param state Pointer to current buffer state
  * @param data TDF data
  *
  * @retval >0 Number of TDFs successfully added to buffer
  * @return -ENOMEM Insufficient space to add any TDFs to buffer
  */
-int tdf_add(uint16_t tdf_id, uint8_t tdf_len, uint8_t tdf_num, uint64_t time, uint16_t period,
-	    struct tdf_buffer_state *state, const void *data);
+int tdf_add(struct tdf_buffer_state *state, uint16_t tdf_id, uint8_t tdf_len, uint8_t tdf_num, uint64_t time,
+	    uint16_t period, const void *data);
 
 /**
  * @brief Initialise TDF parsing state

--- a/subsys/tdf/tdf.c
+++ b/subsys/tdf/tdf.c
@@ -37,8 +37,8 @@ static uint32_t sign_extend_24_bits(uint32_t x)
 	return (x ^ m) - m;
 }
 
-int tdf_add(uint16_t tdf_id, uint8_t tdf_len, uint8_t tdf_num, uint64_t time, uint16_t period,
-	    struct tdf_buffer_state *state, const void *data)
+int tdf_add(struct tdf_buffer_state *state, uint16_t tdf_id, uint8_t tdf_len, uint8_t tdf_num, uint64_t time,
+	    uint16_t period, const void *data)
 {
 	uint16_t buffer_remaining = net_buf_simple_tailroom(&state->buf);
 	uint16_t payload_space;

--- a/tests/subsys/tdf/src/main.c
+++ b/tests/subsys/tdf/src/main.c
@@ -42,7 +42,7 @@ static void run_test_case(struct tdf_test_case *tdfs, size_t num_tdfs)
 	/* Add the requested TDFs */
 	for (int i = 0; i < num_tdfs; i++) {
 		t = &tdfs[i];
-		rc = tdf_add(t->p.tdf_id, t->p.tdf_len, t->p.tdf_num, t->p.time, t->p.period, &state, input_buffer);
+		rc = tdf_add(&state, t->p.tdf_id, t->p.tdf_len, t->p.tdf_num, t->p.time, t->p.period, input_buffer);
 		total_size += t->expected_size;
 		zassert_equal(t->expected_rc, rc);
 		zassert_equal(total_size, state.buf.len);


### PR DESCRIPTION
Make the first argument to `tdf_add` `state` to match the other functions and the general zephyr convention of the device or object being first.