### PR TITLE
[EIS-159] clang-format: set `ColumnLimit: 100`

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,7 +1,7 @@
 --emacs
 --summary-file
 --show-types
---max-line-length=120
+--max-line-length=100
 --min-conf-desc-length=1
 --typedefsfile=scripts/checkpatch/typedefsfile
 # Import sources that shouldn't be checked

--- a/.clang-format
+++ b/.clang-format
@@ -28,7 +28,7 @@ AttributeMacros:
   - __subsystem
 BitFieldColonSpacing: After
 BreakBeforeBraces: Linux
-ColumnLimit: 120
+ColumnLimit: 100
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
 ForEachMacros:

--- a/apps/data_logger/src/environmental.c
+++ b/apps/data_logger/src/environmental.c
@@ -48,8 +48,8 @@ static int env_sampler(void *a, void *b, void *c)
 		tdf_env.humidity = sensor_value_to_centi(&value);
 
 		/* Push the output TDF over serial */
-		tdf_data_logger_log(TDF_DATA_LOGGER_SERIAL | TDF_DATA_LOGGER_UDP, TDF_ENVIRONMENTAL, sizeof(tdf_env),
-				    civil_time_now(), &tdf_env);
+		tdf_data_logger_log(TDF_DATA_LOGGER_SERIAL | TDF_DATA_LOGGER_UDP, TDF_ENVIRONMENTAL,
+				    sizeof(tdf_env), civil_time_now(), &tdf_env);
 
 		/* Print the measured values */
 		LOG_INF("Sensor: %s", env->name);

--- a/apps/data_logger/src/imu.c
+++ b/apps/data_logger/src/imu.c
@@ -63,8 +63,9 @@ static int imu_sampler(void *a, void *b, void *c)
 		}
 		sample_cnt = 0;
 
-		tdf_data_logger_log_array(TDF_DATA_LOGGER_SERIAL | TDF_DATA_LOGGER_UDP, TDF_ACC_4G, sizeof(tdf_acc[0]),
-					  ARRAY_SIZE(tdf_acc), civil_time_now(), 65536 / 10, tdf_acc);
+		tdf_data_logger_log_array(TDF_DATA_LOGGER_SERIAL | TDF_DATA_LOGGER_UDP, TDF_ACC_4G,
+					  sizeof(tdf_acc[0]), ARRAY_SIZE(tdf_acc), civil_time_now(),
+					  65536 / 10, tdf_acc);
 
 		/* Print the measured values */
 		LOG_INF("Sensor: %s", imu->name);

--- a/apps/gateway_usb/src/main.c
+++ b/apps/gateway_usb/src/main.c
@@ -34,7 +34,8 @@ int main(void)
 			.build_num = 4,
 		};
 
-		tdf_data_logger_log_dev(tdf_logger_serial, TDF_ANNOUNCE, (sizeof(announce)), 0, &announce);
+		tdf_data_logger_log_dev(tdf_logger_serial, TDF_ANNOUNCE, (sizeof(announce)), 0,
+					&announce);
 		tdf_data_logger_flush_dev(tdf_logger_serial);
 
 		LOG_INF("Sent uptime %d on %s", announce.uptime, tdf_logger_serial->name);

--- a/apps/gateway_wifi/src/main.c
+++ b/apps/gateway_wifi/src/main.c
@@ -46,7 +46,8 @@ int main(void)
 			.build_num = 4,
 		};
 
-		tdf_data_logger_log_dev(tdf_logger_udp, TDF_ANNOUNCE, (sizeof(announce)), 0, &announce);
+		tdf_data_logger_log_dev(tdf_logger_udp, TDF_ANNOUNCE, (sizeof(announce)), 0,
+					&announce);
 		tdf_data_logger_flush_dev(tdf_logger_udp);
 
 		LOG_INF("Sent uptime %d on %s", announce.uptime, tdf_logger_udp->name);

--- a/boards/arm/nrf7002dk_nrf5340/nrf5340_cpunet_reset.c
+++ b/boards/arm/nrf7002dk_nrf5340/nrf5340_cpunet_reset.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(nrf7002dk_nrf5340_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
 
 static void remoteproc_mgr_config(void)
 {
-#if defined(CONFIG_BT_CTLR_DEBUG_PINS_CPUAPP) &&                                                                       \
+#if defined(CONFIG_BT_CTLR_DEBUG_PINS_CPUAPP) &&                                                   \
 	(!defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(CONFIG_BUILD_WITH_TFM))
 	/* Route Bluetooth Controller Debug Pins */
 	DEBUG_SETUP();

--- a/include/infuse/crypto/ascon.h
+++ b/include/infuse/crypto/ascon.h
@@ -43,9 +43,10 @@ extern "C" {
  *
  * @retval 0 on success
  */
-int ascon128_aead_encrypt(unsigned char *c, unsigned long long *clen, const unsigned char *m, unsigned long long mlen,
-			  const unsigned char *ad, unsigned long long adlen, unsigned char *tag,
-			  const unsigned char *npub, const unsigned char *k);
+int ascon128_aead_encrypt(unsigned char *c, unsigned long long *clen, const unsigned char *m,
+			  unsigned long long mlen, const unsigned char *ad,
+			  unsigned long long adlen, unsigned char *tag, const unsigned char *npub,
+			  const unsigned char *k);
 
 /**
  * @brief Decrypt ciphertext with ascon-128
@@ -63,9 +64,10 @@ int ascon128_aead_encrypt(unsigned char *c, unsigned long long *clen, const unsi
  * @retval 0 on success
  * @retval -1 on error
  */
-int ascon128_aead_decrypt(unsigned char *m, unsigned long long *mlen, const unsigned char *tag, const unsigned char *c,
-			  unsigned long long clen, const unsigned char *ad, unsigned long long adlen,
-			  const unsigned char *npub, const unsigned char *k);
+int ascon128_aead_decrypt(unsigned char *m, unsigned long long *mlen, const unsigned char *tag,
+			  const unsigned char *c, unsigned long long clen, const unsigned char *ad,
+			  unsigned long long adlen, const unsigned char *npub,
+			  const unsigned char *k);
 
 /**
  * @brief Encrypt plaintext with ascon-128a
@@ -82,9 +84,10 @@ int ascon128_aead_decrypt(unsigned char *m, unsigned long long *mlen, const unsi
  *
  * @retval 0 on success
  */
-int ascon128a_aead_encrypt(unsigned char *c, unsigned long long *clen, const unsigned char *m, unsigned long long mlen,
-			   const unsigned char *ad, unsigned long long adlen, unsigned char *tag,
-			   const unsigned char *npub, const unsigned char *k);
+int ascon128a_aead_encrypt(unsigned char *c, unsigned long long *clen, const unsigned char *m,
+			   unsigned long long mlen, const unsigned char *ad,
+			   unsigned long long adlen, unsigned char *tag, const unsigned char *npub,
+			   const unsigned char *k);
 
 /**
  * @brief Decrypt ciphertext with ascon-128a
@@ -102,9 +105,10 @@ int ascon128a_aead_encrypt(unsigned char *c, unsigned long long *clen, const uns
  * @retval 0 on success
  * @retval -1 on error
  */
-int ascon128a_aead_decrypt(unsigned char *m, unsigned long long *mlen, const unsigned char *tag, const unsigned char *c,
-			   unsigned long long clen, const unsigned char *ad, unsigned long long adlen,
-			   const unsigned char *npub, const unsigned char *k);
+int ascon128a_aead_decrypt(unsigned char *m, unsigned long long *mlen, const unsigned char *tag,
+			   const unsigned char *c, unsigned long long clen, const unsigned char *ad,
+			   unsigned long long adlen, const unsigned char *npub,
+			   const unsigned char *k);
 
 /**
  * @brief Encrypt plaintext with ascon-80pq
@@ -121,9 +125,10 @@ int ascon128a_aead_decrypt(unsigned char *m, unsigned long long *mlen, const uns
  *
  * @retval 0 on success
  */
-int ascon80pq_aead_encrypt(unsigned char *c, unsigned long long *clen, const unsigned char *m, unsigned long long mlen,
-			   const unsigned char *ad, unsigned long long adlen, unsigned char *tag,
-			   const unsigned char *npub, const unsigned char *k);
+int ascon80pq_aead_encrypt(unsigned char *c, unsigned long long *clen, const unsigned char *m,
+			   unsigned long long mlen, const unsigned char *ad,
+			   unsigned long long adlen, unsigned char *tag, const unsigned char *npub,
+			   const unsigned char *k);
 
 /**
  * @brief Decrypt ciphertext with ascon-80pq
@@ -141,9 +146,10 @@ int ascon80pq_aead_encrypt(unsigned char *c, unsigned long long *clen, const uns
  * @retval 0 on success
  * @retval -1 on error
  */
-int ascon80pq_aead_decrypt(unsigned char *m, unsigned long long *mlen, const unsigned char *tag, const unsigned char *c,
-			   unsigned long long clen, const unsigned char *ad, unsigned long long adlen,
-			   const unsigned char *npub, const unsigned char *k);
+int ascon80pq_aead_decrypt(unsigned char *m, unsigned long long *mlen, const unsigned char *tag,
+			   const unsigned char *c, unsigned long long clen, const unsigned char *ad,
+			   unsigned long long adlen, const unsigned char *npub,
+			   const unsigned char *k);
 
 /**
  * @}

--- a/include/infuse/data_logger/high_level/tdf.h
+++ b/include/infuse/data_logger/high_level/tdf.h
@@ -55,8 +55,8 @@ enum {
  * @retval 0 On success
  * @retval -errno Error code from @a tdf_add or @a tdf_data_logger_flush on error
  */
-int tdf_data_logger_log_array_dev(const struct device *dev, uint16_t tdf_id, uint8_t tdf_len, uint8_t tdf_num,
-				  uint64_t time, uint16_t period, void *data);
+int tdf_data_logger_log_array_dev(const struct device *dev, uint16_t tdf_id, uint8_t tdf_len,
+				  uint8_t tdf_num, uint64_t time, uint16_t period, void *data);
 
 /**
  * @brief Add multiple TDFs to multiple data loggers
@@ -69,8 +69,8 @@ int tdf_data_logger_log_array_dev(const struct device *dev, uint16_t tdf_id, uin
  * @param period Time period between the TDF samples
  * @param data TDF data array
  */
-void tdf_data_logger_log_array(uint8_t logger_mask, uint16_t tdf_id, uint8_t tdf_len, uint8_t tdf_num, uint64_t time,
-			       uint16_t period, void *data);
+void tdf_data_logger_log_array(uint8_t logger_mask, uint16_t tdf_id, uint8_t tdf_len,
+			       uint8_t tdf_num, uint64_t time, uint16_t period, void *data);
 
 /**
  * @brief Add a single TDF to a data logger
@@ -84,8 +84,8 @@ void tdf_data_logger_log_array(uint8_t logger_mask, uint16_t tdf_id, uint8_t tdf
  * @retval 0 On success
  * @retval -errno Error code from @a tdf_add or @a tdf_data_logger_flush on error
  */
-static inline int tdf_data_logger_log_dev(const struct device *dev, uint16_t tdf_id, uint8_t tdf_len, uint64_t time,
-					  void *data)
+static inline int tdf_data_logger_log_dev(const struct device *dev, uint16_t tdf_id,
+					  uint8_t tdf_len, uint64_t time, void *data)
 {
 	return tdf_data_logger_log_array_dev(dev, tdf_id, tdf_len, 1, time, 0, data);
 }
@@ -99,7 +99,8 @@ static inline int tdf_data_logger_log_dev(const struct device *dev, uint16_t tdf
  * @param time Civil time associated with the TDF. 0 for no timestamp.
  * @param data TDF data
  */
-static inline void tdf_data_logger_log(uint8_t logger_mask, uint16_t tdf_id, uint8_t tdf_len, uint64_t time, void *data)
+static inline void tdf_data_logger_log(uint8_t logger_mask, uint16_t tdf_id, uint8_t tdf_len,
+				       uint64_t time, void *data)
 {
 	tdf_data_logger_log_array(logger_mask, tdf_id, tdf_len, 1, time, 0, data);
 }

--- a/include/infuse/data_logger/logger.h
+++ b/include/infuse/data_logger/logger.h
@@ -72,7 +72,8 @@ void data_logger_get_state(const struct device *dev, struct data_logger_state *s
  * @retval -ENOMEM data logger is full
  * @retval -errno on error
  */
-int data_logger_block_write(const struct device *dev, enum infuse_type type, void *block, uint16_t block_len);
+int data_logger_block_write(const struct device *dev, enum infuse_type type, void *block,
+			    uint16_t block_len);
 
 /**
  * @brief Read a block from the data logger
@@ -92,8 +93,8 @@ int data_logger_block_write(const struct device *dev, enum infuse_type type, voi
  * @retval -ENOENT requested data that does not exist
  * @retval -errno on error
  */
-int data_logger_block_read(const struct device *dev, uint32_t block_idx, uint16_t block_offset, void *block,
-			   uint16_t block_len);
+int data_logger_block_read(const struct device *dev, uint32_t block_idx, uint16_t block_offset,
+			   void *block, uint16_t block_len);
 
 /**
  * @}

--- a/include/infuse/epacket/interface.h
+++ b/include/infuse/epacket/interface.h
@@ -27,14 +27,15 @@ extern "C" {
  */
 
 /* Maximum packet size on an interface, limited by CONFIG_EPACKET_PACKET_SIZE_MAX */
-#define EPACKET_INTERFACE_MAX_PACKET(node_id)                                                                          \
-	(MIN(CONFIG_EPACKET_PACKET_SIZE_MAX, DT_PROP_OR(node_id, max_packet_size, CONFIG_EPACKET_PACKET_SIZE_MAX)))
+#define EPACKET_INTERFACE_MAX_PACKET(node_id)                                                      \
+	(MIN(CONFIG_EPACKET_PACKET_SIZE_MAX,                                                       \
+	     DT_PROP_OR(node_id, max_packet_size, CONFIG_EPACKET_PACKET_SIZE_MAX)))
 /* Get the maximum payload size for a given packet size */
-#define EPACKET_INTERFACE_PAYLOAD_FROM_PACKET(node_id, packet_size)                                                    \
-	(MIN(packet_size, CONFIG_EPACKET_PACKET_SIZE_MAX) - DT_PROP(node_id, header_size) -                            \
+#define EPACKET_INTERFACE_PAYLOAD_FROM_PACKET(node_id, packet_size)                                \
+	(MIN(packet_size, CONFIG_EPACKET_PACKET_SIZE_MAX) - DT_PROP(node_id, header_size) -        \
 	 DT_PROP(node_id, footer_size))
 /* Maximum payload size on an interface */
-#define EPACKET_INTERFACE_MAX_PAYLOAD(node_id)                                                                         \
+#define EPACKET_INTERFACE_MAX_PAYLOAD(node_id)                                                     \
 	(EPACKET_INTERFACE_PAYLOAD_FROM_PACKET(node_id, EPACKET_INTERFACE_MAX_PACKET(node_id)))
 
 /* Identifier for ePacket interface */
@@ -115,7 +116,8 @@ void epacket_queue(const struct device *dev, struct net_buf *buf);
  * @param dev Interface to set handler for
  * @param handler Handler function to run on received packets
  */
-static inline void epacket_set_receive_handler(const struct device *dev, epacket_receive_handler handler)
+static inline void epacket_set_receive_handler(const struct device *dev,
+					       epacket_receive_handler handler)
 {
 	struct epacket_interface_common_data *data = dev->data;
 
@@ -128,7 +130,8 @@ static inline void epacket_set_receive_handler(const struct device *dev, epacket
  * @param dev Interface to receive callbacks for
  * @param cb Callback struct to register
  */
-static inline void epacket_register_callback(const struct device *dev, struct epacket_interface_cb *cb)
+static inline void epacket_register_callback(const struct device *dev,
+					     struct epacket_interface_cb *cb)
 {
 	struct epacket_interface_common_data *data = dev->data;
 

--- a/include/infuse/epacket/interface/epacket_dummy.h
+++ b/include/infuse/epacket/interface/epacket_dummy.h
@@ -65,7 +65,8 @@ void epacket_dummy_set_tx_failure(int error_code);
  * @param extra_len Length of extra payload
  */
 void epacket_dummy_receive_extra(const struct device *dev, const struct epacket_dummy_frame *header,
-				 const void *payload, size_t payload_len, const void *extra, size_t extra_len);
+				 const void *payload, size_t payload_len, const void *extra,
+				 size_t extra_len);
 
 /**
  * @brief Simulate the dummy interface receiving a packet
@@ -75,7 +76,8 @@ void epacket_dummy_receive_extra(const struct device *dev, const struct epacket_
  * @param payload Packet payload
  * @param payload_len Length of payload
  */
-static inline void epacket_dummy_receive(const struct device *dev, const struct epacket_dummy_frame *header,
+static inline void epacket_dummy_receive(const struct device *dev,
+					 const struct epacket_dummy_frame *header,
 					 const void *payload, size_t payload_len)
 {
 	epacket_dummy_receive_extra(dev, header, payload, payload_len, NULL, 0);

--- a/include/infuse/epacket/keys.h
+++ b/include/infuse/epacket/keys.h
@@ -59,8 +59,8 @@ uint32_t epacket_network_key_id(void);
  * @retval -EINVAL on invalid @a base_key
  * @retval -EIO on error
  */
-int epacket_key_derive(enum epacket_key_type base_key, const uint8_t *info, uint8_t info_len, uint32_t salt,
-		       psa_key_id_t *output_key_id);
+int epacket_key_derive(enum epacket_key_type base_key, const uint8_t *info, uint8_t info_len,
+		       uint32_t salt, psa_key_id_t *output_key_id);
 
 /**
  * @brief Get PSA key ID from ePacket key ID

--- a/include/infuse/epacket/packet.h
+++ b/include/infuse/epacket/packet.h
@@ -106,7 +106,8 @@ struct net_buf *epacket_alloc_rx(k_timeout_t timeout);
  * @retval NULL On timeout
  * @retval buf When successfully allocated
  */
-static inline struct net_buf *epacket_alloc_tx_for_interface(const struct device *dev, k_timeout_t timeout)
+static inline struct net_buf *epacket_alloc_tx_for_interface(const struct device *dev,
+							     k_timeout_t timeout)
 {
 	const struct epacket_interface_common_config *config = dev->config;
 	struct net_buf *buf = epacket_alloc_tx(timeout);
@@ -129,8 +130,8 @@ static inline struct net_buf *epacket_alloc_tx_for_interface(const struct device
  * @param flags Desired packet flags
  * @param type Packet type
  */
-static inline void epacket_set_tx_metadata(struct net_buf *buf, enum epacket_auth auth, uint16_t flags,
-					   enum infuse_type type)
+static inline void epacket_set_tx_metadata(struct net_buf *buf, enum epacket_auth auth,
+					   uint16_t flags, enum infuse_type type)
 {
 	struct epacket_tx_metadata *meta = net_buf_user_data(buf);
 

--- a/include/infuse/fs/kv_store.h
+++ b/include/infuse/fs/kv_store.h
@@ -167,7 +167,7 @@ ssize_t kv_store_read_fallback(uint16_t key, void *data, size_t max_data_len, co
  *
  * @return a value from @a kv_store_read_fallback
  */
-#define KV_STORE_READ_FALLBACK(key, data, fallback)                                                                    \
+#define KV_STORE_READ_FALLBACK(key, data, fallback)                                                \
 	kv_store_read_fallback(key, data, sizeof(*data), fallback, sizeof(*fallback))
 
 /**

--- a/include/infuse/reboot.h
+++ b/include/infuse/reboot.h
@@ -95,7 +95,8 @@ FUNC_NORETURN void infuse_reboot(enum infuse_reboot_reason reason, uint32_t info
  * @param info2 Link register at exception
  * @param delay Time delay or absolute time to execute the reboot
  */
-void infuse_reboot_delayed(enum infuse_reboot_reason reason, uint32_t info1, uint32_t info2, k_timeout_t delay);
+void infuse_reboot_delayed(enum infuse_reboot_reason reason, uint32_t info1, uint32_t info2,
+			   k_timeout_t delay);
 
 /**
  * @brief Query the reason for the previous reboot

--- a/include/infuse/tdf/tdf.h
+++ b/include/infuse/tdf/tdf.h
@@ -91,8 +91,8 @@ static inline void tdf_buffer_state_reset(struct tdf_buffer_state *state)
  * @retval -ENOSPC TDF too large to ever fit on buffer
  * @return -ENOMEM Insufficient space to add any TDFs to buffer
  */
-int tdf_add(struct tdf_buffer_state *state, uint16_t tdf_id, uint8_t tdf_len, uint8_t tdf_num, uint64_t time,
-	    uint16_t period, const void *data);
+int tdf_add(struct tdf_buffer_state *state, uint16_t tdf_id, uint8_t tdf_len, uint8_t tdf_num,
+	    uint64_t time, uint16_t period, const void *data);
 
 /**
  * @brief Initialise TDF parsing state

--- a/include/infuse/time/civil.h
+++ b/include/infuse/time/civil.h
@@ -81,7 +81,8 @@ struct civil_time_cb {
 	 * @param new New reference instant
 	 * @param user_ctx User context pointer
 	 */
-	void (*reference_time_updated)(enum civil_time_source source, struct timeutil_sync_instant old,
+	void (*reference_time_updated)(enum civil_time_source source,
+				       struct timeutil_sync_instant old,
 				       struct timeutil_sync_instant new, void *user_ctx);
 
 	/* User provided context pointer */
@@ -167,7 +168,8 @@ static inline uint64_t civil_time_from(uint64_t seconds, uint16_t subseconds)
  * @param subseconds Fractional component of time since GPS epoch
  * @retval civil_time Complete civil time
  */
-static inline uint64_t civil_time_from_gps(uint16_t week, uint32_t week_seconds, uint16_t subseconds)
+static inline uint64_t civil_time_from_gps(uint16_t week, uint32_t week_seconds,
+					   uint16_t subseconds)
 {
 	uint64_t seconds = (SECONDS_PER_WEEK * (uint64_t)week) + week_seconds;
 
@@ -264,7 +266,8 @@ enum civil_time_source civil_time_get_source(void);
  * @retval 0 on success
  * @retval -EINVAL if reference instant is invalid
  */
-int civil_time_set_reference(enum civil_time_source source, struct timeutil_sync_instant *reference);
+int civil_time_set_reference(enum civil_time_source source,
+			     struct timeutil_sync_instant *reference);
 
 /**
  * @brief Query how many seconds ago the reference instant was set

--- a/lib/common_boot.c
+++ b/lib/common_boot.c
@@ -45,8 +45,8 @@ static int infuse_common_boot(void)
 
 	/* Get current reboot count */
 	if (rc == 0) {
-		rc = kv_store_read_fallback(KV_KEY_REBOOTS, &reboot, sizeof(reboot), &reboot_fallback,
-					    sizeof(reboot_fallback));
+		rc = kv_store_read_fallback(KV_KEY_REBOOTS, &reboot, sizeof(reboot),
+					    &reboot_fallback, sizeof(reboot_fallback));
 		if (rc == sizeof(reboot)) {
 			/* Increment reboot counter */
 			reboot.count += 1;
@@ -96,7 +96,8 @@ static int infuse_common_boot(void)
 		/* Restore time knowledge (Assume reboot took 0 ms) */
 		reference.local = 0;
 		reference.ref = reboot_state.civil_time;
-		civil_time_set_reference(TIME_SOURCE_RECOVERED | reboot_state.civil_time_source, &reference);
+		civil_time_set_reference(TIME_SOURCE_RECOVERED | reboot_state.civil_time_source,
+					 &reference);
 	} else {
 		LOG_INF("\t   Cause: Unknown");
 	}

--- a/lib/reboot.c
+++ b/lib/reboot.c
@@ -75,7 +75,8 @@ FUNC_NORETURN void infuse_reboot(enum infuse_reboot_reason reason, uint32_t info
 	sys_reboot(SYS_REBOOT_WARM);
 }
 
-void infuse_reboot_delayed(enum infuse_reboot_reason reason, uint32_t info1, uint32_t info2, k_timeout_t delay)
+void infuse_reboot_delayed(enum infuse_reboot_reason reason, uint32_t info1, uint32_t info2,
+			   k_timeout_t delay)
 {
 	static struct k_work_delayable reboot_worker;
 

--- a/lib/time/civil.c
+++ b/lib/time/civil.c
@@ -99,8 +99,8 @@ int civil_time_set_reference(enum civil_time_source source, struct timeutil_sync
 		struct tm c;
 
 		civil_time_unix_calendar(now, &c);
-		LOG_INF("Now: %d-%02d-%02dT%02d:%02d:%02d.%03d UTC", 1900 + c.tm_year, 1 + c.tm_mon, c.tm_mday,
-			c.tm_hour, c.tm_min, c.tm_sec, civil_time_milliseconds(now));
+		LOG_INF("Now: %d-%02d-%02dT%02d:%02d:%02d.%03d UTC", 1900 + c.tm_year, 1 + c.tm_mon,
+			c.tm_mday, c.tm_hour, c.tm_min, c.tm_sec, civil_time_milliseconds(now));
 #endif /* CONFIG_INFUSE_CIVIL_TIME_PRINT_ON_SYNC */
 	}
 	return rc;

--- a/samples/crypto/profiling/src/main.c
+++ b/samples/crypto/profiling/src/main.c
@@ -98,18 +98,20 @@ int main(void)
 			unsigned long long mlen;
 
 			start_time = timing_counter_get();
-			ascon128a_aead_encrypt(ciphertext, &clen, plaintext, plaintext_lengths[i], associated_data, 4,
-					       tag, nonce, key);
+			ascon128a_aead_encrypt(ciphertext, &clen, plaintext, plaintext_lengths[i],
+					       associated_data, 4, tag, nonce, key);
 			end_time = timing_counter_get();
 
-			encrypt_cycles[ASCON_128A][i][r] = timing_cycles_get(&start_time, &end_time);
+			encrypt_cycles[ASCON_128A][i][r] =
+				timing_cycles_get(&start_time, &end_time);
 
 			start_time = timing_counter_get();
-			rc = ascon128a_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen, associated_data, 4, nonce,
-						    key);
+			rc = ascon128a_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen,
+						    associated_data, 4, nonce, key);
 			end_time = timing_counter_get();
 
-			decrypt_cycles[ASCON_128A][i][r] = timing_cycles_get(&start_time, &end_time);
+			decrypt_cycles[ASCON_128A][i][r] =
+				timing_cycles_get(&start_time, &end_time);
 		}
 #endif /* CONFIG_CRYPTO_ASCON_128A */
 #ifdef CONFIG_CRYPTO_ASCON_128
@@ -118,15 +120,15 @@ int main(void)
 			unsigned long long mlen;
 
 			start_time = timing_counter_get();
-			ascon128_aead_encrypt(ciphertext, &clen, plaintext, plaintext_lengths[i], associated_data, 4,
-					      tag, nonce, key);
+			ascon128_aead_encrypt(ciphertext, &clen, plaintext, plaintext_lengths[i],
+					      associated_data, 4, tag, nonce, key);
 			end_time = timing_counter_get();
 
 			encrypt_cycles[ASCON_128][i][r] = timing_cycles_get(&start_time, &end_time);
 
 			start_time = timing_counter_get();
-			rc = ascon128_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen, associated_data, 4, nonce,
-						   key);
+			rc = ascon128_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen,
+						   associated_data, 4, nonce, key);
 			end_time = timing_counter_get();
 
 			decrypt_cycles[ASCON_128][i][r] = timing_cycles_get(&start_time, &end_time);
@@ -138,18 +140,20 @@ int main(void)
 			unsigned long long mlen;
 
 			start_time = timing_counter_get();
-			ascon80pq_aead_encrypt(ciphertext, &clen, plaintext, plaintext_lengths[i], associated_data, 4,
-					       tag, nonce, key);
+			ascon80pq_aead_encrypt(ciphertext, &clen, plaintext, plaintext_lengths[i],
+					       associated_data, 4, tag, nonce, key);
 			end_time = timing_counter_get();
 
-			encrypt_cycles[ASCON_80PQ][i][r] = timing_cycles_get(&start_time, &end_time);
+			encrypt_cycles[ASCON_80PQ][i][r] =
+				timing_cycles_get(&start_time, &end_time);
 
 			start_time = timing_counter_get();
-			rc = ascon80pq_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen, associated_data, 4, nonce,
-						    key);
+			rc = ascon80pq_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen,
+						    associated_data, 4, nonce, key);
 			end_time = timing_counter_get();
 
-			decrypt_cycles[ASCON_80PQ][i][r] = timing_cycles_get(&start_time, &end_time);
+			decrypt_cycles[ASCON_80PQ][i][r] =
+				timing_cycles_get(&start_time, &end_time);
 		}
 #endif /* CONFIG_CRYPTO_ASCON_80PQ */
 		for (int r = 0; r < REPEATS; r++) {
@@ -157,23 +161,27 @@ int main(void)
 
 			start_time = timing_counter_get();
 
-			status = psa_aead_encrypt(key_id, PSA_ALG_CHACHA20_POLY1305, nonce, 12, associated_data, 4,
-						  plaintext, plaintext_lengths[i], ciphertext, sizeof(ciphertext),
-						  &clen);
+			status = psa_aead_encrypt(key_id, PSA_ALG_CHACHA20_POLY1305, nonce, 12,
+						  associated_data, 4, plaintext,
+						  plaintext_lengths[i], ciphertext,
+						  sizeof(ciphertext), &clen);
 			end_time = timing_counter_get();
 			if (status != PSA_SUCCESS) {
 				LOG_INF("psa_aead_encrypt failed! (Error: %d)", status);
 			}
-			encrypt_cycles[CHACHA20_POLY1305][i][r] = timing_cycles_get(&start_time, &end_time);
+			encrypt_cycles[CHACHA20_POLY1305][i][r] =
+				timing_cycles_get(&start_time, &end_time);
 
 			start_time = timing_counter_get();
-			status = psa_aead_decrypt(key_id, PSA_ALG_CHACHA20_POLY1305, nonce, 12, associated_data, 4,
-						  ciphertext, clen, decrypted, sizeof(decrypted), &mlen);
+			status = psa_aead_decrypt(key_id, PSA_ALG_CHACHA20_POLY1305, nonce, 12,
+						  associated_data, 4, ciphertext, clen, decrypted,
+						  sizeof(decrypted), &mlen);
 			end_time = timing_counter_get();
 			if (status != PSA_SUCCESS) {
 				LOG_INF("psa_aead_decrypt failed! (Error: %d)", status);
 			}
-			decrypt_cycles[CHACHA20_POLY1305][i][r] = timing_cycles_get(&start_time, &end_time);
+			decrypt_cycles[CHACHA20_POLY1305][i][r] =
+				timing_cycles_get(&start_time, &end_time);
 		}
 	}
 
@@ -197,8 +205,8 @@ int main(void)
 			encr_ns = timing_cycles_to_ns(encr_avg);
 			decr_ns = timing_cycles_to_ns(decr_avg);
 
-			LOG_INF("\tLength %4d Encrypt %6llu (%7llu ns) Decrypt %6llu (%7llu ns)", plaintext_lengths[j],
-				encr_avg, encr_ns, decr_avg, decr_ns);
+			LOG_INF("\tLength %4d Encrypt %6llu (%7llu ns) Decrypt %6llu (%7llu ns)",
+				plaintext_lengths[j], encr_avg, encr_ns, decr_avg, decr_ns);
 		}
 	}
 	k_sleep(K_FOREVER);

--- a/subsys/data_logger/backends/backend_api.h
+++ b/subsys/data_logger/backends/backend_api.h
@@ -72,8 +72,8 @@ struct data_logger_backend_api {
 	 * @retval 0 on success
 	 * @retval -errno otherwise
 	 */
-	int (*write)(const struct data_logger_backend_config *config, uint32_t phy_block, enum infuse_type data_type,
-		     const void *data, uint16_t data_len);
+	int (*write)(const struct data_logger_backend_config *config, uint32_t phy_block,
+		     enum infuse_type data_type, const void *data, uint16_t data_len);
 
 	/**
 	 * @brief Read data from the given backend block
@@ -89,8 +89,8 @@ struct data_logger_backend_api {
 	 * @retval 0 on success
 	 * @retval -errno otherwise
 	 */
-	int (*read)(const struct data_logger_backend_config *config, uint32_t phy_block, uint16_t block_offset,
-		    void *data, uint16_t data_len);
+	int (*read)(const struct data_logger_backend_config *config, uint32_t phy_block,
+		    uint16_t block_offset, void *data, uint16_t data_len);
 
 	/**
 	 * @brief Erase all data from the given backend
@@ -102,7 +102,8 @@ struct data_logger_backend_api {
 	 * @retval 0 on success
 	 * @retval -errno otherwise
 	 */
-	int (*erase)(const struct data_logger_backend_config *config, uint32_t phy_block, uint32_t num);
+	int (*erase)(const struct data_logger_backend_config *config, uint32_t phy_block,
+		     uint32_t num);
 };
 
 /**

--- a/subsys/data_logger/backends/epacket.c
+++ b/subsys/data_logger/backends/epacket.c
@@ -15,8 +15,9 @@
 #include "backend_api.h"
 #include "epacket.h"
 
-static int logger_epacket_write(const struct data_logger_backend_config *backend, uint32_t phy_block,
-				enum infuse_type data_type, const void *mem, uint16_t mem_len)
+static int logger_epacket_write(const struct data_logger_backend_config *backend,
+				uint32_t phy_block, enum infuse_type data_type, const void *mem,
+				uint16_t mem_len)
 {
 	struct net_buf *buf = epacket_alloc_tx_for_interface(backend->backend, K_FOREVER);
 

--- a/subsys/data_logger/backends/epacket.h
+++ b/subsys/data_logger/backends/epacket.h
@@ -21,15 +21,15 @@
 extern "C" {
 #endif
 
-#define DATA_LOGGER_BACKEND_CONFIG_EPACKET(node, data_ptr)                                                             \
-	.backend_api = &data_logger_epacket_api,                                                                       \
-	.backend_config = {                                                                                            \
-		.data = data_ptr,                                                                                      \
-		.backend = DEVICE_DT_GET(DT_PROP(node, epacket)),                                                      \
-		.logical_blocks = UINT32_MAX,                                                                          \
-		.physical_blocks = UINT32_MAX,                                                                         \
-		.erase_size = 0,                                                                                       \
-		.max_block_size = EPACKET_INTERFACE_MAX_PAYLOAD(DT_PROP(node, epacket)),                               \
+#define DATA_LOGGER_BACKEND_CONFIG_EPACKET(node, data_ptr)                                         \
+	.backend_api = &data_logger_epacket_api,                                                   \
+	.backend_config = {                                                                        \
+		.data = data_ptr,                                                                  \
+		.backend = DEVICE_DT_GET(DT_PROP(node, epacket)),                                  \
+		.logical_blocks = UINT32_MAX,                                                      \
+		.physical_blocks = UINT32_MAX,                                                     \
+		.erase_size = 0,                                                                   \
+		.max_block_size = EPACKET_INTERFACE_MAX_PAYLOAD(DT_PROP(node, epacket)),           \
 	},
 
 extern const struct data_logger_backend_api data_logger_epacket_api;

--- a/subsys/data_logger/backends/flash_map.c
+++ b/subsys/data_logger/backends/flash_map.c
@@ -15,8 +15,9 @@
 #include "backend_api.h"
 #include "flash_map.h"
 
-static int logger_flash_map_write(const struct data_logger_backend_config *backend, uint32_t phy_block,
-				  enum infuse_type data_type, const void *mem, uint16_t mem_len)
+static int logger_flash_map_write(const struct data_logger_backend_config *backend,
+				  uint32_t phy_block, enum infuse_type data_type, const void *mem,
+				  uint16_t mem_len)
 {
 	struct data_logger_backend_data *data = backend->data;
 	off_t offset = DATA_LOGGER_FLASH_MAP_BLOCK_SIZE * phy_block;
@@ -33,8 +34,9 @@ static int logger_flash_map_write(const struct data_logger_backend_config *backe
 	return flash_area_write(data->area, offset, mem, mem_len);
 }
 
-static int logger_flash_map_read(const struct data_logger_backend_config *backend, uint32_t phy_block,
-				 uint16_t block_offset, void *mem, uint16_t mem_len)
+static int logger_flash_map_read(const struct data_logger_backend_config *backend,
+				 uint32_t phy_block, uint16_t block_offset, void *mem,
+				 uint16_t mem_len)
 {
 	struct data_logger_backend_data *data = backend->data;
 	off_t offset = (DATA_LOGGER_FLASH_MAP_BLOCK_SIZE * phy_block) + block_offset;
@@ -42,7 +44,8 @@ static int logger_flash_map_read(const struct data_logger_backend_config *backen
 	return flash_area_read(data->area, offset, mem, mem_len);
 }
 
-static int logger_flash_map_erase(const struct data_logger_backend_config *backend, uint32_t phy_block, uint32_t num)
+static int logger_flash_map_erase(const struct data_logger_backend_config *backend,
+				  uint32_t phy_block, uint32_t num)
 {
 	struct data_logger_backend_data *data = backend->data;
 	off_t offset = DATA_LOGGER_FLASH_MAP_BLOCK_SIZE * phy_block;

--- a/subsys/data_logger/backends/flash_map.h
+++ b/subsys/data_logger/backends/flash_map.h
@@ -18,16 +18,19 @@ extern "C" {
 #define DATA_LOGGER_FLASH_MAP_BLOCK_SIZE 512
 #define DATA_LOGGER_FLASH_MAP_MAX_WRAPS  254
 
-#define DATA_LOGGER_BACKEND_CONFIG_FLASH_MAP(node, data_ptr)                                                           \
-	.backend_api = &data_logger_flash_map_api,                                                                     \
-	.backend_config = {                                                                                            \
-		.data = data_ptr,                                                                                      \
-		.flash_area_id = DT_FIXED_PARTITION_ID(DT_PROP(node, partition)),                                      \
-		.logical_blocks = (DT_REG_SIZE(DT_PROP(node, partition)) / DATA_LOGGER_FLASH_MAP_BLOCK_SIZE) *         \
-				  DATA_LOGGER_FLASH_MAP_MAX_WRAPS,                                                     \
-		.physical_blocks = (DT_REG_SIZE(DT_PROP(node, partition)) / DATA_LOGGER_FLASH_MAP_BLOCK_SIZE),         \
-		.erase_size = DT_PROP_OR(DT_GPARENT(DT_PROP(node, partition)), erase_block_size, 4096),                \
-		.max_block_size = DATA_LOGGER_FLASH_MAP_BLOCK_SIZE,                                                    \
+#define DATA_LOGGER_BACKEND_CONFIG_FLASH_MAP(node, data_ptr)                                       \
+	.backend_api = &data_logger_flash_map_api,                                                 \
+	.backend_config = {                                                                        \
+		.data = data_ptr,                                                                  \
+		.flash_area_id = DT_FIXED_PARTITION_ID(DT_PROP(node, partition)),                  \
+		.logical_blocks = (DT_REG_SIZE(DT_PROP(node, partition)) /                         \
+				   DATA_LOGGER_FLASH_MAP_BLOCK_SIZE) *                             \
+				  DATA_LOGGER_FLASH_MAP_MAX_WRAPS,                                 \
+		.physical_blocks = (DT_REG_SIZE(DT_PROP(node, partition)) /                        \
+				    DATA_LOGGER_FLASH_MAP_BLOCK_SIZE),                             \
+		.erase_size =                                                                      \
+			DT_PROP_OR(DT_GPARENT(DT_PROP(node, partition)), erase_block_size, 4096),  \
+		.max_block_size = DATA_LOGGER_FLASH_MAP_BLOCK_SIZE,                                \
 	},
 
 extern const struct data_logger_backend_api data_logger_flash_map_api;

--- a/subsys/data_logger/data_logger.c
+++ b/subsys/data_logger/data_logger.c
@@ -44,16 +44,19 @@ void data_logger_get_state(const struct device *dev, struct data_logger_state *s
 	state->current_block = data->current_block;
 	state->earliest_block = data->earliest_block;
 	state->block_size = data->backend_data.block_size;
-	state->block_overhead =
-		config->backend_api->read == NULL ? 0 : sizeof(struct data_logger_persistent_block_header);
+	state->block_overhead = config->backend_api->read == NULL
+					? 0
+					: sizeof(struct data_logger_persistent_block_header);
 	state->erase_unit = config->backend_config.erase_size;
 }
 
-int data_logger_block_write(const struct device *dev, enum infuse_type type, void *block, uint16_t block_len)
+int data_logger_block_write(const struct device *dev, enum infuse_type type, void *block,
+			    uint16_t block_len)
 {
 	const struct data_logger_config *config = dev->config;
 	struct data_logger_data *data = dev->data;
-	uint16_t erase_blocks = config->backend_config.erase_size / config->backend_config.max_block_size;
+	uint16_t erase_blocks =
+		config->backend_config.erase_size / config->backend_config.max_block_size;
 	uint32_t phy_block = data->current_block % config->backend_config.physical_blocks;
 	int rc;
 
@@ -66,7 +69,8 @@ int data_logger_block_write(const struct device *dev, enum infuse_type type, voi
 		return -ENOMEM;
 	}
 
-	LOG_DBG("%s writing to logical block %d (Phy block %d)", dev->name, data->current_block, phy_block);
+	LOG_DBG("%s writing to logical block %d (Phy block %d)", dev->name, data->current_block,
+		phy_block);
 	/* Erase next chunk if required */
 	if ((data->current_block >= config->backend_config.physical_blocks) &&
 	    ((data->current_block % erase_blocks) == 0)) {
@@ -85,7 +89,8 @@ int data_logger_block_write(const struct device *dev, enum infuse_type type, voi
 		struct data_logger_persistent_block_header *header = block;
 
 		header->block_type = type;
-		header->block_wrap = (data->current_block / config->backend_config.physical_blocks) + 1;
+		header->block_wrap =
+			(data->current_block / config->backend_config.physical_blocks) + 1;
 	}
 
 	/* Write block to backend */
@@ -98,13 +103,14 @@ int data_logger_block_write(const struct device *dev, enum infuse_type type, voi
 	return 0;
 }
 
-int data_logger_block_read(const struct device *dev, uint32_t block_idx, uint16_t block_offset, void *block,
-			   uint16_t block_len)
+int data_logger_block_read(const struct device *dev, uint32_t block_idx, uint16_t block_offset,
+			   void *block, uint16_t block_len)
 {
 	const struct data_logger_config *config = dev->config;
 	struct data_logger_data *data = dev->data;
 	uint32_t phy_block = block_idx % config->backend_config.physical_blocks;
-	uint32_t end_logical = ((config->backend_config.max_block_size * block_idx) + block_offset + block_len - 1) /
+	uint32_t end_logical = ((config->backend_config.max_block_size * block_idx) + block_offset +
+				block_len - 1) /
 			       config->backend_config.max_block_size;
 	uint32_t end_phy = end_logical % config->backend_config.physical_blocks;
 	uint32_t second_read = 0;
@@ -123,9 +129,9 @@ int data_logger_block_read(const struct device *dev, uint32_t block_idx, uint16_
 
 	/* Read goes across the wrap boundary */
 	if (end_phy < phy_block) {
-		uint32_t bytes_to_wrap =
-			(config->backend_config.physical_blocks - phy_block) * config->backend_config.max_block_size -
-			block_offset;
+		uint32_t bytes_to_wrap = (config->backend_config.physical_blocks - phy_block) *
+						 config->backend_config.max_block_size -
+					 block_offset;
 
 		LOG_DBG("%s read wraps across boundary after %d bytes", dev->name, bytes_to_wrap);
 		second_read = block_len - bytes_to_wrap;
@@ -133,7 +139,8 @@ int data_logger_block_read(const struct device *dev, uint32_t block_idx, uint16_
 	}
 
 	/* Read block from backend */
-	rc = config->backend_api->read(&config->backend_config, phy_block, block_offset, block, block_len);
+	rc = config->backend_api->read(&config->backend_config, phy_block, block_offset, block,
+				       block_len);
 	if (rc < 0) {
 		LOG_ERR("%s failed to read from backend", dev->name);
 	}
@@ -159,7 +166,8 @@ static int current_block_search(const struct device *dev, uint8_t counter)
 	/* Binary search for last block where block_wrap == counter */
 	while (low <= high) {
 		mid = (low + high) / 2;
-		rc = config->backend_api->read(&config->backend_config, mid, 0, &temp, sizeof(temp));
+		rc = config->backend_api->read(&config->backend_config, mid, 0, &temp,
+					       sizeof(temp));
 		if (rc < 0) {
 			return rc;
 		}
@@ -176,7 +184,8 @@ static int current_block_search(const struct device *dev, uint8_t counter)
 	data->earliest_block = data->current_block - config->backend_config.physical_blocks;
 	res = (data->earliest_block % config->backend_config.physical_blocks);
 	while (true) {
-		rc = config->backend_api->read(&config->backend_config, res, 0, &temp, sizeof(temp));
+		rc = config->backend_api->read(&config->backend_config, res, 0, &temp,
+					       sizeof(temp));
 		if (rc < 0) {
 			return rc;
 		}
@@ -229,7 +238,8 @@ int data_logger_init(const struct device *dev)
 	if (rc < 0) {
 		return rc;
 	}
-	rc = config->backend_api->read(&config->backend_config, config->backend_config.physical_blocks - 1, 0, &last,
+	rc = config->backend_api->read(&config->backend_config,
+				       config->backend_config.physical_blocks - 1, 0, &last,
 				       sizeof(last));
 	if (rc < 0) {
 		return rc;
@@ -243,13 +253,16 @@ int data_logger_init(const struct device *dev)
 			data->current_block = 0;
 		} else {
 			/* All blocks written with same wrap */
-			data->current_block = first.block_wrap * config->backend_config.physical_blocks;
-			data->earliest_block = data->current_block - config->backend_config.physical_blocks;
+			data->current_block =
+				first.block_wrap * config->backend_config.physical_blocks;
+			data->earliest_block =
+				data->current_block - config->backend_config.physical_blocks;
 		}
 	} else if ((first.block_wrap == 0x00 || first.block_wrap == 0xFF)) {
 		/* First chunk has been erased after a complete write */
 		data->current_block = last.block_wrap * config->backend_config.physical_blocks;
-		data->earliest_block = data->current_block - config->backend_config.physical_blocks + erase_blocks;
+		data->earliest_block =
+			data->current_block - config->backend_config.physical_blocks + erase_blocks;
 	} else {
 		/* Search for current block */
 		rc = current_block_search(dev, first.block_wrap);
@@ -259,18 +272,23 @@ int data_logger_init(const struct device *dev)
 		}
 	}
 
-	LOG_INF("%s -> %d/%d blocks", dev->name, data->current_block, config->backend_config.logical_blocks);
+	LOG_INF("%s -> %d/%d blocks", dev->name, data->current_block,
+		config->backend_config.logical_blocks);
 	return 0;
 }
 
-#define DATA_LOGGER_DEFINE(inst)                                                                                       \
-	static struct data_logger_data data##inst;                                                                     \
-	static struct data_logger_config config##inst = {                                                              \
-		COND_CODE_1(DT_NODE_HAS_COMPAT(DT_DRV_INST(inst), embeint_data_logger_flash_map),                      \
-			    (DATA_LOGGER_BACKEND_CONFIG_FLASH_MAP(DT_DRV_INST(inst), &data##inst.backend_data)), ())   \
-			COND_CODE_1(DT_NODE_HAS_COMPAT(DT_DRV_INST(inst), embeint_data_logger_epacket),                \
-				    (DATA_LOGGER_BACKEND_CONFIG_EPACKET(DT_DRV_INST(inst), &data##inst.backend_data)), \
-				    ())};                                                                              \
-	DEVICE_DT_INST_DEFINE(inst, data_logger_init, NULL, &data##inst, &config##inst, POST_KERNEL, 80, NULL);
+#define DATA_LOGGER_DEFINE(inst)                                                                   \
+	static struct data_logger_data data##inst;                                                 \
+	static struct data_logger_config config##inst = {                                          \
+		COND_CODE_1(DT_NODE_HAS_COMPAT(DT_DRV_INST(inst), embeint_data_logger_flash_map),  \
+			    (DATA_LOGGER_BACKEND_CONFIG_FLASH_MAP(DT_DRV_INST(inst),               \
+								  &data##inst.backend_data)),      \
+			    ()) COND_CODE_1(DT_NODE_HAS_COMPAT(DT_DRV_INST(inst),                  \
+							       embeint_data_logger_epacket),       \
+					    (DATA_LOGGER_BACKEND_CONFIG_EPACKET(                   \
+						    DT_DRV_INST(inst), &data##inst.backend_data)), \
+					    ())};                                                  \
+	DEVICE_DT_INST_DEFINE(inst, data_logger_init, NULL, &data##inst, &config##inst,            \
+			      POST_KERNEL, 80, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(DATA_LOGGER_DEFINE)

--- a/subsys/epacket/epacket.c
+++ b/subsys/epacket/epacket.c
@@ -86,7 +86,8 @@ static void epacket_handle_rx(struct net_buf *buf)
 
 	interface_data = metadata->interface->data;
 
-	LOG_DBG("%s: received %d byte packet (%d dBm)", metadata->interface->name, buf->len, metadata->rssi);
+	LOG_DBG("%s: received %d byte packet (%d dBm)", metadata->interface->name, buf->len,
+		metadata->rssi);
 
 	/* Payload decoding */
 	switch (metadata->interface_id) {
@@ -94,7 +95,8 @@ static void epacket_handle_rx(struct net_buf *buf)
 	case EPACKET_INTERFACE_SERIAL:
 		if (buf->len == 0) {
 			/* Serial echo packet, respond */
-			struct net_buf *echo = epacket_alloc_tx_for_interface(metadata->interface, K_FOREVER);
+			struct net_buf *echo =
+				epacket_alloc_tx_for_interface(metadata->interface, K_FOREVER);
 
 			epacket_set_tx_metadata(echo, EPACKET_AUTH_DEVICE, 0, INFUSE_ECHO_RSP);
 			epacket_queue(metadata->interface, echo);
@@ -146,10 +148,10 @@ static void epacket_handle_tx(struct net_buf *buf)
 static int epacket_processor(void *a, void *b, void *c)
 {
 	struct k_poll_event events[2] = {
-		K_POLL_EVENT_STATIC_INITIALIZER(K_POLL_TYPE_FIFO_DATA_AVAILABLE, K_POLL_MODE_NOTIFY_ONLY,
-						&epacket_rx_queue, 0),
-		K_POLL_EVENT_STATIC_INITIALIZER(K_POLL_TYPE_FIFO_DATA_AVAILABLE, K_POLL_MODE_NOTIFY_ONLY,
-						&epacket_tx_queue, 0),
+		K_POLL_EVENT_STATIC_INITIALIZER(K_POLL_TYPE_FIFO_DATA_AVAILABLE,
+						K_POLL_MODE_NOTIFY_ONLY, &epacket_rx_queue, 0),
+		K_POLL_EVENT_STATIC_INITIALIZER(K_POLL_TYPE_FIFO_DATA_AVAILABLE,
+						K_POLL_MODE_NOTIFY_ONLY, &epacket_tx_queue, 0),
 	};
 	struct net_buf *buf;
 
@@ -171,4 +173,5 @@ static int epacket_processor(void *a, void *b, void *c)
 	return 0;
 }
 
-K_THREAD_DEFINE(epacket_processor_thread, 2048, epacket_processor, NULL, NULL, NULL, 0, K_ESSENTIAL, 0);
+K_THREAD_DEFINE(epacket_processor_thread, 2048, epacket_processor, NULL, NULL, NULL, 0, K_ESSENTIAL,
+		0);

--- a/subsys/epacket/handlers.c
+++ b/subsys/epacket/handlers.c
@@ -19,8 +19,8 @@ void epacket_default_receive_handler(struct net_buf *buf)
 {
 	struct epacket_rx_metadata *meta = net_buf_user_data(buf);
 
-	LOG_DBG("Received on %s: Auth=%d Type=%d Seq=%d Len=%d", meta->interface->name, meta->auth, meta->type,
-		meta->sequence, buf->len);
+	LOG_DBG("Received on %s: Auth=%d Type=%d Seq=%d Len=%d", meta->interface->name, meta->auth,
+		meta->type, meta->sequence, buf->len);
 
 	if (meta->auth == EPACKET_AUTH_FAILURE) {
 		goto done;

--- a/subsys/epacket/interfaces/epacket_dummy.c
+++ b/subsys/epacket/interfaces/epacket_dummy.c
@@ -35,7 +35,8 @@ void epacket_dummy_set_tx_failure(int error_code)
 }
 
 void epacket_dummy_receive_extra(const struct device *dev, const struct epacket_dummy_frame *header,
-				 const void *payload, size_t payload_len, const void *extra, size_t extra_len)
+				 const void *payload, size_t payload_len, const void *extra,
+				 size_t extra_len)
 {
 	struct net_buf *rx = epacket_alloc_rx(K_FOREVER);
 	struct epacket_rx_metadata *meta = net_buf_user_data(rx);
@@ -101,14 +102,14 @@ static const struct epacket_interface_api dummy_api = {
 	.send = epacket_dummy_send,
 };
 
-#define EPACKET_DUMMY_DEFINE(inst)                                                                                     \
-	BUILD_ASSERT(sizeof(struct epacket_dummy_frame) == DT_INST_PROP(inst, header_size));                           \
-	static struct epacket_interface_common_data epacket_dummy_data##inst;                                          \
-	static const struct epacket_interface_common_config epacket_dummy_config##inst = {                             \
-		.header_size = DT_INST_PROP(inst, header_size),                                                        \
-		.footer_size = DT_INST_PROP(inst, footer_size),                                                        \
-	};                                                                                                             \
-	DEVICE_DT_INST_DEFINE(inst, epacket_dummy_init, NULL, &epacket_dummy_data##inst, &epacket_dummy_config##inst,  \
-			      POST_KERNEL, 0, &dummy_api);
+#define EPACKET_DUMMY_DEFINE(inst)                                                                 \
+	BUILD_ASSERT(sizeof(struct epacket_dummy_frame) == DT_INST_PROP(inst, header_size));       \
+	static struct epacket_interface_common_data epacket_dummy_data##inst;                      \
+	static const struct epacket_interface_common_config epacket_dummy_config##inst = {         \
+		.header_size = DT_INST_PROP(inst, header_size),                                    \
+		.footer_size = DT_INST_PROP(inst, footer_size),                                    \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(inst, epacket_dummy_init, NULL, &epacket_dummy_data##inst,           \
+			      &epacket_dummy_config##inst, POST_KERNEL, 0, &dummy_api);
 
 DT_INST_FOREACH_STATUS_OKAY(EPACKET_DUMMY_DEFINE)

--- a/subsys/epacket/interfaces/epacket_serial.c
+++ b/subsys/epacket/interfaces/epacket_serial.c
@@ -46,7 +46,8 @@ LOG_MODULE_REGISTER(epacket_serial, CONFIG_EPACKET_SERIAL_LOG_LEVEL);
 static void disconnected_handler(struct k_work *work)
 {
 	struct k_work_delayable *delayable = k_work_delayable_from_work(work);
-	struct epacket_serial_data *data = CONTAINER_OF(delayable, struct epacket_serial_data, dc_handler);
+	struct epacket_serial_data *data =
+		CONTAINER_OF(delayable, struct epacket_serial_data, dc_handler);
 	struct net_buf *buf;
 	int cnt = 0;
 
@@ -167,19 +168,20 @@ static const struct epacket_interface_api serial_api = {
 	.send = epacket_serial_send,
 };
 
-#define EPACKET_SERIAL_DEFINE(inst)                                                                                    \
-	BUILD_ASSERT(sizeof(struct epacket_serial_frame_header) + sizeof(struct epacket_serial_frame) ==               \
-		     DT_INST_PROP(inst, header_size));                                                                 \
-	static struct epacket_serial_data serial_data_##inst;                                                          \
-	static const struct epacket_serial_config serial_config_##inst = {                                             \
-		.common =                                                                                              \
-			{                                                                                              \
-				.header_size = DT_INST_PROP(inst, header_size),                                        \
-				.footer_size = DT_INST_PROP(inst, footer_size),                                        \
-			},                                                                                             \
-		.backend = DEVICE_DT_GET(DT_INST_PROP(inst, serial)),                                                  \
-	};                                                                                                             \
-	DEVICE_DT_INST_DEFINE(inst, epacket_serial_init, NULL, &serial_data_##inst, &serial_config_##inst,             \
-			      POST_KERNEL, 0, &serial_api);
+#define EPACKET_SERIAL_DEFINE(inst)                                                                \
+	BUILD_ASSERT(sizeof(struct epacket_serial_frame_header) +                                  \
+			     sizeof(struct epacket_serial_frame) ==                                \
+		     DT_INST_PROP(inst, header_size));                                             \
+	static struct epacket_serial_data serial_data_##inst;                                      \
+	static const struct epacket_serial_config serial_config_##inst = {                         \
+		.common =                                                                          \
+			{                                                                          \
+				.header_size = DT_INST_PROP(inst, header_size),                    \
+				.footer_size = DT_INST_PROP(inst, footer_size),                    \
+			},                                                                         \
+		.backend = DEVICE_DT_GET(DT_INST_PROP(inst, serial)),                              \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(inst, epacket_serial_init, NULL, &serial_data_##inst,                \
+			      &serial_config_##inst, POST_KERNEL, 0, &serial_api);
 
 DT_INST_FOREACH_STATUS_OKAY(EPACKET_SERIAL_DEFINE)

--- a/subsys/epacket/interfaces/epacket_serial_crypt.c
+++ b/subsys/epacket/interfaces/epacket_serial_crypt.c
@@ -180,9 +180,10 @@ int epacket_serial_encrypt(struct net_buf *buf)
 	net_buf_add_mem(scratch, net_buf_remove_mem(buf, buf_len), buf_len);
 
 	/* Encrypt back into the original buffer */
-	status = psa_aead_encrypt(psa_key_id, PSA_ALG_CHACHA20_POLY1305, frame->nonce.raw, sizeof(frame->nonce.raw),
-				  frame->associated_data.raw, sizeof(frame->associated_data), scratch->data,
-				  scratch->len, net_buf_tail(buf), net_buf_tailroom(buf), &out_len);
+	status = psa_aead_encrypt(psa_key_id, PSA_ALG_CHACHA20_POLY1305, frame->nonce.raw,
+				  sizeof(frame->nonce.raw), frame->associated_data.raw,
+				  sizeof(frame->associated_data), scratch->data, scratch->len,
+				  net_buf_tail(buf), net_buf_tailroom(buf), &out_len);
 	net_buf_add(buf, out_len);
 
 	/* Free scratch space */
@@ -218,7 +219,8 @@ int epacket_serial_decrypt(struct net_buf *buf)
 	if (frame.associated_data.flags & EPACKET_FLAGS_ENCRYPTION_DEVICE) {
 		meta->auth = EPACKET_AUTH_DEVICE;
 		/* Validate packet is for us */
-		device_id = ((uint64_t)frame.associated_data.device_id_upper << 32) | frame.nonce.device_id_lower;
+		device_id = ((uint64_t)frame.associated_data.device_id_upper << 32) |
+			    frame.nonce.device_id_lower;
 		if (device_id != infuse_device_id()) {
 			goto error;
 		}
@@ -232,7 +234,8 @@ int epacket_serial_decrypt(struct net_buf *buf)
 			goto error;
 		}
 		key_id = EPACKET_KEY_NETWORK | EPACKET_KEY_INTERFACE_SERIAL;
-		key_rotation = (frame.associated_data.flags & EPACKET_FLAGS_ROTATE_NETWORK_MASK) >> 12;
+		key_rotation =
+			(frame.associated_data.flags & EPACKET_FLAGS_ROTATE_NETWORK_MASK) >> 12;
 		switch (key_rotation) {
 		case EPACKET_FLAGS_ROTATE_NETWORK_EACH_MINUTE:
 			key_period = SECONDS_PER_MINUTE;
@@ -266,8 +269,9 @@ int epacket_serial_decrypt(struct net_buf *buf)
 	net_buf_reset(buf);
 
 	/* Decrypt back into original buffer */
-	status = psa_aead_decrypt(psa_key_id, PSA_ALG_CHACHA20_POLY1305, frame.nonce.raw, sizeof(frame.nonce),
-				  frame.associated_data.raw, sizeof(frame.associated_data), scratch->data, scratch->len,
+	status = psa_aead_decrypt(psa_key_id, PSA_ALG_CHACHA20_POLY1305, frame.nonce.raw,
+				  sizeof(frame.nonce), frame.associated_data.raw,
+				  sizeof(frame.associated_data), scratch->data, scratch->len,
 				  net_buf_tail(buf), net_buf_tailroom(buf), &out_len);
 
 	if (status != PSA_SUCCESS) {

--- a/subsys/epacket/interfaces/epacket_udp.c
+++ b/subsys/epacket/interfaces/epacket_udp.c
@@ -67,7 +67,8 @@ static void cleanup_interface(const struct device *epacket_udp)
 	}
 }
 
-static void l4_event_handler(struct net_mgmt_event_callback *cb, uint32_t event, struct net_if *iface)
+static void l4_event_handler(struct net_mgmt_event_callback *cb, uint32_t event,
+			     struct net_if *iface)
 {
 	if (event == NET_EVENT_L4_CONNECTED) {
 		LOG_INF("Network connected");
@@ -82,7 +83,8 @@ static void l4_event_handler(struct net_mgmt_event_callback *cb, uint32_t event,
 static int epacket_udp_dns_query(void)
 {
 	KV_STRING_CONST(udp_url_default, CONFIG_EPACKET_INTERFACE_UDP_DEFAULT_URL);
-	KV_KEY_TYPE(KV_KEY_EPACKET_UDP_PORT) udp_port, udp_port_default = {CONFIG_EPACKET_INTERFACE_UDP_DEFAULT_PORT};
+	KV_KEY_TYPE(KV_KEY_EPACKET_UDP_PORT)
+	udp_port, udp_port_default = {CONFIG_EPACKET_INTERFACE_UDP_DEFAULT_PORT};
 	KV_KEY_TYPE_VAR(KV_KEY_EPACKET_UDP_URL, 64) udp_url;
 	struct zsock_addrinfo hints = {
 		.ai_family = AF_INET,
@@ -111,7 +113,8 @@ static int epacket_udp_dns_query(void)
 	sockaddr->sin_port = htons(udp_port.port);
 	addr = sockaddr->sin_addr.s4_addr;
 
-	LOG_INF("%s -> %d.%d.%d.%d:%d", udp_url.server.value, addr[0], addr[1], addr[2], addr[3], udp_port.port);
+	LOG_INF("%s -> %d.%d.%d.%d:%d", udp_url.server.value, addr[0], addr[1], addr[2], addr[3],
+		udp_port.port);
 	return rc;
 }
 
@@ -176,7 +179,8 @@ static int epacket_udp_loop(void *a, void *b, void *c)
 			buf = epacket_alloc_rx(K_FOREVER);
 			meta = net_buf_user_data(buf);
 			/* Receive data into local buffer */
-			received = zsock_recvfrom(udp_state.sock, buf->data, buf->size, 0, &from, &from_len);
+			received = zsock_recvfrom(udp_state.sock, buf->data, buf->size, 0, &from,
+						  &from_len);
 			if (received < 0) {
 				LOG_ERR("Failed to receive (%d)", errno);
 				net_buf_unref(buf);
@@ -185,8 +189,8 @@ static int epacket_udp_loop(void *a, void *b, void *c)
 			net_buf_add(buf, received);
 			addr = ((struct sockaddr_in *)&from)->sin_addr.s4_addr;
 			port = ((struct sockaddr_in *)&from)->sin_port;
-			LOG_DBG("Received %d bytes from %d.%d.%d.%d:%d", received, addr[0], addr[1], addr[2], addr[3],
-				port);
+			LOG_DBG("Received %d bytes from %d.%d.%d.%d:%d", received, addr[0], addr[1],
+				addr[2], addr[3], port);
 
 			meta->interface = epacket_udp;
 			meta->interface_id = EPACKET_INTERFACE_UDP;
@@ -228,7 +232,8 @@ static void epacket_udp_send(const struct device *dev, struct net_buf *buf)
 
 	/* Send to remote server */
 	LOG_DBG("Sending %d bytes to server", buf->len);
-	rc = zsock_sendto(udp_state.sock, buf->data, buf->len, 0, &udp_state.remote, udp_state.remote_len);
+	rc = zsock_sendto(udp_state.sock, buf->data, buf->len, 0, &udp_state.remote,
+			  udp_state.remote_len);
 	if (rc == -1) {
 		LOG_WRN("Failed to send (%d)", errno);
 		epacket_notify_tx_failure(dev, buf, -errno);
@@ -260,5 +265,5 @@ static const struct epacket_interface_common_config epacket_udp_config = {
 	.header_size = DT_INST_PROP(0, header_size),
 	.footer_size = DT_INST_PROP(0, footer_size),
 };
-DEVICE_DT_DEFINE(DT_DRV_INST(0), epacket_udp_init, NULL, &epacket_udp_data, &epacket_udp_config, POST_KERNEL, 0,
-		 &udp_api);
+DEVICE_DT_DEFINE(DT_DRV_INST(0), epacket_udp_init, NULL, &epacket_udp_data, &epacket_udp_config,
+		 POST_KERNEL, 0, &udp_api);

--- a/subsys/epacket/interfaces/epacket_udp_crypt.c
+++ b/subsys/epacket/interfaces/epacket_udp_crypt.c
@@ -88,9 +88,10 @@ int epacket_udp_encrypt(struct net_buf *buf)
 	net_buf_add_mem(scratch, net_buf_remove_mem(buf, buf_len), buf_len);
 
 	/* Encrypt back into the original buffer */
-	status = psa_aead_encrypt(psa_key_id, PSA_ALG_CHACHA20_POLY1305, frame->nonce.raw, sizeof(frame->nonce.raw),
-				  frame->associated_data.raw, sizeof(frame->associated_data), scratch->data,
-				  scratch->len, net_buf_tail(buf), net_buf_tailroom(buf), &out_len);
+	status = psa_aead_encrypt(psa_key_id, PSA_ALG_CHACHA20_POLY1305, frame->nonce.raw,
+				  sizeof(frame->nonce.raw), frame->associated_data.raw,
+				  sizeof(frame->associated_data), scratch->data, scratch->len,
+				  net_buf_tail(buf), net_buf_tailroom(buf), &out_len);
 	net_buf_add(buf, out_len);
 
 	/* Free scratch space */
@@ -124,8 +125,10 @@ int epacket_udp_decrypt(struct net_buf *buf)
 	meta->sequence = frame.nonce.sequence;
 
 	/* Validate packet should be for us and device encrypted */
-	device_id = ((uint64_t)frame.associated_data.device_id_upper << 32) | frame.nonce.device_id_lower;
-	if ((device_id != infuse_device_id()) || !(frame.associated_data.flags & EPACKET_FLAGS_ENCRYPTION_DEVICE)) {
+	device_id = ((uint64_t)frame.associated_data.device_id_upper << 32) |
+		    frame.nonce.device_id_lower;
+	if ((device_id != infuse_device_id()) ||
+	    !(frame.associated_data.flags & EPACKET_FLAGS_ENCRYPTION_DEVICE)) {
 		goto error;
 	}
 
@@ -146,8 +149,9 @@ int epacket_udp_decrypt(struct net_buf *buf)
 	net_buf_reset(buf);
 
 	/* Decrypt into the allocated packet buffer */
-	status = psa_aead_decrypt(psa_key_id, PSA_ALG_CHACHA20_POLY1305, frame.nonce.raw, sizeof(frame.nonce),
-				  frame.associated_data.raw, sizeof(frame.associated_data), scratch->data, scratch->len,
+	status = psa_aead_decrypt(psa_key_id, PSA_ALG_CHACHA20_POLY1305, frame.nonce.raw,
+				  sizeof(frame.nonce), frame.associated_data.raw,
+				  sizeof(frame.associated_data), scratch->data, scratch->len,
 				  net_buf_tail(buf), net_buf_tailroom(buf), &out_len);
 
 	if (status != PSA_SUCCESS) {

--- a/subsys/epacket/keys.c
+++ b/subsys/epacket/keys.c
@@ -59,11 +59,13 @@ static int epacket_import_root_keys(void)
 	psa_set_key_bits(&key_attributes, 128);
 
 	/* Import the base keys into the keystore */
-	status = psa_import_key(&key_attributes, device_key, sizeof(device_key), &device_root_key_id);
+	status = psa_import_key(&key_attributes, device_key, sizeof(device_key),
+				&device_root_key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_WRN("Failed to import %s root (%d)", "device", status);
 	}
-	status = psa_import_key(&key_attributes, network_key, sizeof(network_key), &network_root_key_id);
+	status = psa_import_key(&key_attributes, network_key, sizeof(network_key),
+				&network_root_key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_WRN("Failed to import %s root (%d)", "root", status);
 	}
@@ -75,8 +77,8 @@ uint32_t epacket_network_key_id(void)
 	return network_id;
 }
 
-int epacket_key_derive(enum epacket_key_type base_key, const uint8_t *info, uint8_t info_len, uint32_t salt,
-		       psa_key_id_t *output_key_id)
+int epacket_key_derive(enum epacket_key_type base_key, const uint8_t *info, uint8_t info_len,
+		       uint32_t salt, psa_key_id_t *output_key_id)
 {
 	psa_key_attributes_t key_attributes = PSA_KEY_ATTRIBUTES_INIT;
 	psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
@@ -117,8 +119,10 @@ int epacket_key_derive(enum epacket_key_type base_key, const uint8_t *info, uint
 #endif /* CONFIG_EPACKET_KEY_EXPORT */
 
 	if (psa_key_derivation_setup(&operation, PSA_ALG_HKDF(PSA_ALG_SHA_256)) ||
-	    psa_key_derivation_input_bytes(&operation, PSA_KEY_DERIVATION_INPUT_SALT, (uint8_t *)&salt, sizeof(salt)) ||
-	    psa_key_derivation_input_bytes(&operation, PSA_KEY_DERIVATION_INPUT_INFO, info, info_len) ||
+	    psa_key_derivation_input_bytes(&operation, PSA_KEY_DERIVATION_INPUT_SALT,
+					   (uint8_t *)&salt, sizeof(salt)) ||
+	    psa_key_derivation_input_bytes(&operation, PSA_KEY_DERIVATION_INPUT_INFO, info,
+					   info_len) ||
 	    psa_key_derivation_input_key(&operation, PSA_KEY_DERIVATION_INPUT_SECRET, input_key) ||
 	    psa_key_derivation_output_key(&key_attributes, &operation, output_key_id) ||
 	    psa_key_derivation_abort(&operation)) {
@@ -158,9 +162,11 @@ psa_key_id_t epacket_key_id_get(uint8_t key_id, uint32_t key_rotation)
 		if (storage[interface].id) {
 			epacket_key_delete(storage[interface].id);
 		}
-		LOG_INF("Regenerating derived key %02X (%s) for rotation %d", key_id, info, key_rotation);
+		LOG_INF("Regenerating derived key %02X (%s) for rotation %d", key_id, info,
+			key_rotation);
 		ticks = k_uptime_ticks();
-		rc = epacket_key_derive(base, info, strlen(info), key_rotation, &storage[interface].id);
+		rc = epacket_key_derive(base, info, strlen(info), key_rotation,
+					&storage[interface].id);
 		ticks = k_uptime_ticks() - ticks;
 		LOG_DBG("Generation took %d uS", k_cyc_to_us_near32(ticks));
 		if (rc == 0) {

--- a/subsys/fs/kv_store/kv_store.c
+++ b/subsys/fs/kv_store/kv_store.c
@@ -153,7 +153,8 @@ ssize_t kv_store_read(uint16_t key, void *data, size_t max_data_len)
 	return nvs_read(&fs, key, data, max_data_len);
 }
 
-ssize_t kv_store_read_fallback(uint16_t key, void *data, size_t max_data_len, const void *fallback, size_t fallback_len)
+ssize_t kv_store_read_fallback(uint16_t key, void *data, size_t max_data_len, const void *fallback,
+			       size_t fallback_len)
 {
 	struct kv_store_cb *cb;
 	ssize_t rc;
@@ -174,7 +175,8 @@ ssize_t kv_store_read_fallback(uint16_t key, void *data, size_t max_data_len, co
 			/* Notify interested parties of value write */
 			SYS_SLIST_FOR_EACH_CONTAINER(&cb_list, cb, node) {
 				if (cb->value_changed) {
-					cb->value_changed(key, fallback, fallback_len, cb->user_ctx);
+					cb->value_changed(key, fallback, fallback_len,
+							  cb->user_ctx);
 				}
 			}
 			/* Read data back out */

--- a/subsys/net/conn_mgr/conn_mgr_wifi_kv_store.c
+++ b/subsys/net/conn_mgr/conn_mgr_wifi_kv_store.c
@@ -50,7 +50,8 @@ static void conn_create_worker(struct k_work *work)
 
 	/* Initiate connection */
 	LOG_INF("Initiating connection to '%s'", params.ssid);
-	(void)net_mgmt(NET_REQUEST_WIFI_CONNECT, wifi_if, &params, sizeof(struct wifi_connect_req_params));
+	(void)net_mgmt(NET_REQUEST_WIFI_CONNECT, wifi_if, &params,
+		       sizeof(struct wifi_connect_req_params));
 }
 
 static void conn_timeout_worker(struct k_work *work)
@@ -62,7 +63,8 @@ static void conn_timeout_worker(struct k_work *work)
 	net_mgmt_event_notify(NET_EVENT_CONN_IF_TIMEOUT, wifi_if);
 }
 
-static void wifi_mgmt_event_handler(struct net_mgmt_event_callback *cb, uint32_t mgmt_event, struct net_if *iface)
+static void wifi_mgmt_event_handler(struct net_mgmt_event_callback *cb, uint32_t mgmt_event,
+				    struct net_if *iface)
 {
 	const struct wifi_status *status = cb->info;
 	bool persistent = conn_mgr_if_get_flag(wifi_if, CONN_MGR_IF_PERSISTENT);
@@ -85,7 +87,8 @@ static void wifi_mgmt_event_handler(struct net_mgmt_event_callback *cb, uint32_t
 		}
 		break;
 	case NET_EVENT_WIFI_DISCONNECT_RESULT:
-		LOG_INF("Connection lost (%d)%s", status->disconn_reason, persistent ? ", retrying" : "");
+		LOG_INF("Connection lost (%d)%s", status->disconn_reason,
+			persistent ? ", retrying" : "");
 		if (persistent) {
 #ifdef CONFIG_WPA_SUPP
 			/* WPA SUPP automatically attempts to reconnect */
@@ -115,7 +118,8 @@ static void wifi_mgmt_event_handler(struct net_mgmt_event_callback *cb, uint32_t
 static struct net_mgmt_event_callback wpa_supp_cb;
 static K_SEM_DEFINE(wpa_supp_ready_sem, 0, 1);
 
-static void wpa_supp_event_handler(struct net_mgmt_event_callback *cb, uint32_t mgmt_event, struct net_if *iface)
+static void wpa_supp_event_handler(struct net_mgmt_event_callback *cb, uint32_t mgmt_event,
+				   struct net_if *iface)
 {
 	switch (mgmt_event) {
 	case NET_EVENT_WPA_SUPP_READY:
@@ -173,7 +177,8 @@ static void wifi_mgmt_init(struct conn_mgr_conn_binding *const binding)
 	net_mgmt_add_event_callback(&wifi_mgmt_cb);
 
 #ifdef CONFIG_WPA_SUPP
-	net_mgmt_init_event_callback(&wpa_supp_cb, wpa_supp_event_handler, NET_EVENT_WPA_SUPP_READY);
+	net_mgmt_init_event_callback(&wpa_supp_cb, wpa_supp_event_handler,
+				     NET_EVENT_WPA_SUPP_READY);
 	net_mgmt_add_event_callback(&wpa_supp_cb);
 	k_sem_take(&wpa_supp_ready_sem, K_FOREVER);
 #endif /* CONFIG_WPA_SUPP */

--- a/subsys/net/sntp/auto_sntp.c
+++ b/subsys/net/sntp/auto_sntp.c
@@ -23,7 +23,8 @@ static struct k_work_delayable sntp_worker;
 
 LOG_MODULE_REGISTER(sntp_auto, CONFIG_SNTP_AUTO_LOG_LEVEL);
 
-static void l4_event_handler(struct net_mgmt_event_callback *cb, uint32_t event, struct net_if *iface)
+static void l4_event_handler(struct net_mgmt_event_callback *cb, uint32_t event,
+			     struct net_if *iface)
 {
 	k_timeout_t delay = K_NO_WAIT;
 	uint32_t sync_age;
@@ -78,7 +79,8 @@ static void sntp_work(struct k_work *work)
 	addr.sin_port = htons(123);
 
 	a = addr.sin_addr.s4_addr;
-	LOG_INF("%s -> %d.%d.%d.%d:%d", ntp_server.url.value, a[0], a[1], a[2], a[3], ntohs(addr.sin_port));
+	LOG_INF("%s -> %d.%d.%d.%d:%d", ntp_server.url.value, a[0], a[1], a[2], a[3],
+		ntohs(addr.sin_port));
 
 	rc = sntp_init(&ctx, (struct sockaddr *)&addr, sizeof(struct sockaddr_in));
 	if (rc < 0) {

--- a/subsys/rpc/commands/kv_write.c
+++ b/subsys/rpc/commands/kv_write.c
@@ -32,7 +32,8 @@ struct net_buf *rpc_command_kv_write(struct net_buf *request)
 		consumed = sizeof(struct rpc_struct_kv_store_value) + v->len;
 		offset += consumed;
 		if (offset > request->len) {
-			LOG_WRN("%s invalid buffer (idx %d key %d len %d)", __func__, i, v->id, v->len);
+			LOG_WRN("%s invalid buffer (idx %d key %d len %d)", __func__, i, v->id,
+				v->len);
 			return rpc_response_simple_req(request, -EINVAL, &rsp, sizeof(rsp));
 		}
 	}

--- a/subsys/rpc/commands/reboot.c
+++ b/subsys/rpc/commands/reboot.c
@@ -27,7 +27,8 @@ struct net_buf *rpc_command_reboot(struct net_buf *request)
 	/* Allocate the response packet */
 	response = rpc_response_simple_req(request, 0, &rsp, sizeof(rsp));
 	/* Schedule the reboot */
-	infuse_reboot_delayed(INFUSE_REBOOT_RPC, (uintptr_t)rpc_command_reboot, 0x00, K_MSEC(rsp.delay_ms));
+	infuse_reboot_delayed(INFUSE_REBOOT_RPC, (uintptr_t)rpc_command_reboot, 0x00,
+			      K_MSEC(rsp.delay_ms));
 	LOG_INF("%s: Rebooting in %d ms", __func__, rsp.delay_ms);
 	/* Return the response */
 	return response;

--- a/subsys/rpc/server.c
+++ b/subsys/rpc/server.c
@@ -33,7 +33,8 @@ void rpc_server_queue_data(struct net_buf *buf)
 	net_buf_put(&data_fifo, buf);
 }
 
-struct net_buf *rpc_response_simple_if(const struct device *interface, int16_t rc, void *response, size_t len)
+struct net_buf *rpc_response_simple_if(const struct device *interface, int16_t rc, void *response,
+				       size_t len)
 {
 	struct net_buf *response_buf = epacket_alloc_tx_for_interface(interface, K_FOREVER);
 	struct infuse_rpc_rsp_header *header = net_buf_add_mem(response_buf, response, len);
@@ -42,7 +43,8 @@ struct net_buf *rpc_response_simple_if(const struct device *interface, int16_t r
 	return response_buf;
 }
 
-struct net_buf *rpc_response_simple_req(struct net_buf *request, int16_t rc, void *response, size_t len)
+struct net_buf *rpc_response_simple_req(struct net_buf *request, int16_t rc, void *response,
+					size_t len)
 {
 	struct epacket_rx_metadata *metadata = net_buf_user_data(request);
 
@@ -55,7 +57,8 @@ void rpc_server_pull_data_reset(void)
 	data_packet_ack_counter = 0;
 }
 
-struct net_buf *rpc_server_pull_data(uint32_t request_id, uint32_t expected_offset, k_timeout_t timeout)
+struct net_buf *rpc_server_pull_data(uint32_t request_id, uint32_t expected_offset,
+				     k_timeout_t timeout)
 {
 	struct infuse_rpc_data *data;
 	struct net_buf *buf;
@@ -73,7 +76,8 @@ struct net_buf *rpc_server_pull_data(uint32_t request_id, uint32_t expected_offs
 		}
 		data = (void *)buf->data;
 		if (data->request_id != request_id) {
-			LOG_WRN("Mismatched request ID (%08X != %08X)", data->request_id, request_id);
+			LOG_WRN("Mismatched request ID (%08X != %08X)", data->request_id,
+				request_id);
 			net_buf_unref(buf);
 			continue;
 		}
@@ -84,7 +88,8 @@ struct net_buf *rpc_server_pull_data(uint32_t request_id, uint32_t expected_offs
 	}
 }
 
-void rpc_server_ack_data(const struct device *interface, uint32_t request_id, uint32_t offset, uint8_t ack_period)
+void rpc_server_ack_data(const struct device *interface, uint32_t request_id, uint32_t offset,
+			 uint8_t ack_period)
 {
 	struct infuse_rpc_data_ack *data_ack;
 	struct net_buf *ack;
@@ -100,7 +105,8 @@ void rpc_server_ack_data(const struct device *interface, uint32_t request_id, ui
 			epacket_set_tx_metadata(ack, EPACKET_AUTH_NETWORK, 0, INFUSE_RPC_DATA_ACK);
 			/* Populate data */
 			data_ack->request_id = request_id;
-			net_buf_add_mem(ack, data_packet_acks, data_packet_ack_counter * sizeof(uint32_t));
+			net_buf_add_mem(ack, data_packet_acks,
+					data_packet_ack_counter * sizeof(uint32_t));
 			/* Send the RPC_DATA_ACK and reset */
 			epacket_queue(interface, ack);
 			rpc_server_pull_data_reset();
@@ -111,10 +117,10 @@ void rpc_server_ack_data(const struct device *interface, uint32_t request_id, ui
 static int rpc_server(void *a, void *b, void *c)
 {
 	struct k_poll_event events[2] = {
-		K_POLL_EVENT_STATIC_INITIALIZER(K_POLL_TYPE_FIFO_DATA_AVAILABLE, K_POLL_MODE_NOTIFY_ONLY, &command_fifo,
-						0),
-		K_POLL_EVENT_STATIC_INITIALIZER(K_POLL_TYPE_FIFO_DATA_AVAILABLE, K_POLL_MODE_NOTIFY_ONLY, &data_fifo,
-						0),
+		K_POLL_EVENT_STATIC_INITIALIZER(K_POLL_TYPE_FIFO_DATA_AVAILABLE,
+						K_POLL_MODE_NOTIFY_ONLY, &command_fifo, 0),
+		K_POLL_EVENT_STATIC_INITIALIZER(K_POLL_TYPE_FIFO_DATA_AVAILABLE,
+						K_POLL_MODE_NOTIFY_ONLY, &data_fifo, 0),
 	};
 	struct infuse_rpc_data *data;
 	struct net_buf *buf;
@@ -131,10 +137,11 @@ static int rpc_server(void *a, void *b, void *c)
 
 		if (events[1].state == K_POLL_STATE_FIFO_DATA_AVAILABLE) {
 			buf = net_buf_get(events[1].fifo, K_NO_WAIT);
-			/* Can return NULL if data packet was queued before `rpc_command_runner` started */
+			/* Can return NULL if data packet was queued before runner started */
 			if (buf) {
 				data = (void *)buf->data;
-				LOG_WRN("Dropping data for command %08X %08x", data->request_id, data->offset);
+				LOG_WRN("Dropping data for command %08X %08x", data->request_id,
+					data->offset);
 				net_buf_unref(buf);
 			}
 			events[1].state = K_POLL_STATE_NOT_READY;
@@ -143,5 +150,5 @@ static int rpc_server(void *a, void *b, void *c)
 	return 0;
 }
 
-K_THREAD_DEFINE(rpc_server_thread, CONFIG_INFUSE_RPC_SERVER_STACK_SIZE, rpc_server, NULL, NULL, NULL, 0, K_ESSENTIAL,
-		0);
+K_THREAD_DEFINE(rpc_server_thread, CONFIG_INFUSE_RPC_SERVER_STACK_SIZE, rpc_server, NULL, NULL,
+		NULL, 0, K_ESSENTIAL, 0);

--- a/subsys/rpc/server.h
+++ b/subsys/rpc/server.h
@@ -27,7 +27,8 @@ extern "C" {
  *
  * @return struct net_buf* packet buffer
  */
-struct net_buf *rpc_response_simple_if(const struct device *interface, int16_t rc, void *response, size_t len);
+struct net_buf *rpc_response_simple_if(const struct device *interface, int16_t rc, void *response,
+				       size_t len);
 
 /**
  * @brief Create an @ref INFUSE_RPC_RSP packet buffer from a request
@@ -39,7 +40,8 @@ struct net_buf *rpc_response_simple_if(const struct device *interface, int16_t r
  *
  * @return struct net_buf* packet buffer
  */
-struct net_buf *rpc_response_simple_req(struct net_buf *request, int16_t rc, void *response, size_t len);
+struct net_buf *rpc_response_simple_req(struct net_buf *request, int16_t rc, void *response,
+					size_t len);
 
 /**
  * @brief Get the size of the variable component of the @ref INFUSE_RPC_REQ packet
@@ -61,7 +63,8 @@ struct net_buf *rpc_response_simple_req(struct net_buf *request, int16_t rc, voi
  * @retval buf @ref INFUSE_RPC_DATA packet on success
  * @retval NULL on timeout
  */
-struct net_buf *rpc_server_pull_data(uint32_t request_id, uint32_t expected_offset, k_timeout_t timeout);
+struct net_buf *rpc_server_pull_data(uint32_t request_id, uint32_t expected_offset,
+				     k_timeout_t timeout);
 
 /**
  * @brief Acknowledge received data packets
@@ -71,7 +74,8 @@ struct net_buf *rpc_server_pull_data(uint32_t request_id, uint32_t expected_offs
  * @param offset Offset of the received data
  * @param ack_period RX acknowledgment period
  */
-void rpc_server_ack_data(const struct device *interface, uint32_t request_id, uint32_t offset, uint8_t ack_period);
+void rpc_server_ack_data(const struct device *interface, uint32_t request_id, uint32_t offset,
+			 uint8_t ack_period);
 
 #ifdef __cplusplus
 }

--- a/subsys/tdf/tdf.c
+++ b/subsys/tdf/tdf.c
@@ -37,12 +37,13 @@ static uint32_t sign_extend_24_bits(uint32_t x)
 	return (x ^ m) - m;
 }
 
-int tdf_add(struct tdf_buffer_state *state, uint16_t tdf_id, uint8_t tdf_len, uint8_t tdf_num, uint64_t time,
-	    uint16_t period, const void *data)
+int tdf_add(struct tdf_buffer_state *state, uint16_t tdf_id, uint8_t tdf_len, uint8_t tdf_num,
+	    uint64_t time, uint16_t period, const void *data)
 {
 	uint16_t buffer_remaining = net_buf_simple_tailroom(&state->buf);
 	uint16_t max_space = state->buf.size - (state->buf.data - state->buf.__buf);
-	uint16_t min_size = sizeof(struct tdf_header) + (time ? sizeof(struct tdf_time) : 0) + tdf_len;
+	uint16_t min_size =
+		sizeof(struct tdf_header) + (time ? sizeof(struct tdf_time) : 0) + tdf_len;
 	uint16_t payload_space;
 	uint16_t total_header, total_data;
 	uint16_t array_header = 0;
@@ -137,7 +138,8 @@ int tdf_add(struct tdf_buffer_state *state, uint16_t tdf_id, uint8_t tdf_len, ui
 	}
 	/* Add array header */
 	if (tdf_num > 1) {
-		struct tdf_time_array_header *t = net_buf_simple_add(&state->buf, sizeof(struct tdf_time_array_header));
+		struct tdf_time_array_header *t =
+			net_buf_simple_add(&state->buf, sizeof(struct tdf_time_array_header));
 
 		header->id_flags |= TDF_TIME_ARRAY;
 		t->num = tdf_num;

--- a/tests/lib/civil_time/src/main.c
+++ b/tests/lib/civil_time/src/main.c
@@ -23,7 +23,8 @@ ZTEST(civil_time, test_time_source_valid)
 	zassert_false(civil_time_trusted_source(33, true));
 	zassert_false(civil_time_trusted_source(TIME_SOURCE_RECOVERED | TIME_SOURCE_NONE, false));
 	zassert_false(civil_time_trusted_source(TIME_SOURCE_RECOVERED | TIME_SOURCE_NONE, true));
-	zassert_false(civil_time_trusted_source(TIME_SOURCE_RECOVERED | TIME_SOURCE_INVALID, false));
+	zassert_false(
+		civil_time_trusted_source(TIME_SOURCE_RECOVERED | TIME_SOURCE_INVALID, false));
 	zassert_false(civil_time_trusted_source(TIME_SOURCE_RECOVERED | TIME_SOURCE_INVALID, true));
 	zassert_false(civil_time_trusted_source(TIME_SOURCE_RECOVERED | 33, false));
 	zassert_false(civil_time_trusted_source(TIME_SOURCE_RECOVERED | 33, true));
@@ -42,7 +43,8 @@ ZTEST(civil_time, test_time_source_valid)
 	zassert_true(civil_time_trusted_source(TIME_SOURCE_RECOVERED | TIME_SOURCE_RPC, true));
 }
 
-static void validate_unix_conversions(struct tm *expected, uint64_t gps_time, uint64_t unix_time, uint16_t subseconds)
+static void validate_unix_conversions(struct tm *expected, uint64_t gps_time, uint64_t unix_time,
+				      uint16_t subseconds)
 {
 	struct tm calendar;
 	uint64_t civil_time;
@@ -302,9 +304,12 @@ ZTEST(civil_time, test_get_failure)
 	infuse_sync_state.base.ref = 0;
 
 	/* Sync state should be reset  */
-	zassert_equal(1261872018 + 0, civil_time_seconds(civil_time_from_ticks(0 * CONFIG_SYS_CLOCK_TICKS_PER_SEC)));
-	zassert_equal(1261872018 + 1, civil_time_seconds(civil_time_from_ticks(1 * CONFIG_SYS_CLOCK_TICKS_PER_SEC)));
-	zassert_equal(1261872018 + 2, civil_time_seconds(civil_time_from_ticks(2 * CONFIG_SYS_CLOCK_TICKS_PER_SEC)));
+	zassert_equal(1261872018 + 0, civil_time_seconds(civil_time_from_ticks(
+					      0 * CONFIG_SYS_CLOCK_TICKS_PER_SEC)));
+	zassert_equal(1261872018 + 1, civil_time_seconds(civil_time_from_ticks(
+					      1 * CONFIG_SYS_CLOCK_TICKS_PER_SEC)));
+	zassert_equal(1261872018 + 2, civil_time_seconds(civil_time_from_ticks(
+					      2 * CONFIG_SYS_CLOCK_TICKS_PER_SEC)));
 
 	/* Manually force sync state to be invalid */
 	infuse_sync_state.base.local = 1234560;
@@ -312,9 +317,12 @@ ZTEST(civil_time, test_get_failure)
 	infuse_sync_state.skew = -0.1f;
 
 	/* Sync state should be reset  */
-	zassert_equal(1261872018 + 0, civil_time_seconds(civil_time_from_ticks(0 * CONFIG_SYS_CLOCK_TICKS_PER_SEC)));
-	zassert_equal(1261872018 + 1, civil_time_seconds(civil_time_from_ticks(1 * CONFIG_SYS_CLOCK_TICKS_PER_SEC)));
-	zassert_equal(1261872018 + 2, civil_time_seconds(civil_time_from_ticks(2 * CONFIG_SYS_CLOCK_TICKS_PER_SEC)));
+	zassert_equal(1261872018 + 0, civil_time_seconds(civil_time_from_ticks(
+					      0 * CONFIG_SYS_CLOCK_TICKS_PER_SEC)));
+	zassert_equal(1261872018 + 1, civil_time_seconds(civil_time_from_ticks(
+					      1 * CONFIG_SYS_CLOCK_TICKS_PER_SEC)));
+	zassert_equal(1261872018 + 2, civil_time_seconds(civil_time_from_ticks(
+					      2 * CONFIG_SYS_CLOCK_TICKS_PER_SEC)));
 }
 
 ZTEST_SUITE(civil_time, NULL, NULL, NULL, NULL, NULL);

--- a/tests/lib/crypto/ascon/src/main.c
+++ b/tests/lib/crypto/ascon/src/main.c
@@ -41,8 +41,8 @@ ZTEST(ascon, test_ascon128)
 
 	for (int size = 1; size < 128; size++) {
 		/* Encrypt the payload */
-		rc = ascon128_aead_encrypt(ciphertext, &clen, plaintext, size, associated_data, sizeof(associated_data),
-					   tag, nonce, key);
+		rc = ascon128_aead_encrypt(ciphertext, &clen, plaintext, size, associated_data,
+					   sizeof(associated_data), tag, nonce, key);
 		zassert_equal(0, rc, "Encryption failed");
 		zassert_equal(size, clen, "Unexpected ciphertext length");
 
@@ -102,10 +102,12 @@ ZTEST(ascon, test_ascon128_associated_data)
 	zassert_mem_equal(plaintext, decrypted, size, "Decrypted does not equal input");
 
 	/* Small associated data */
-	rc = ascon128_aead_encrypt(ciphertext, &clen, plaintext, size, associated_data, 4, tag, nonce, key);
+	rc = ascon128_aead_encrypt(ciphertext, &clen, plaintext, size, associated_data, 4, tag,
+				   nonce, key);
 	zassert_equal(0, rc, "Encryption failed");
 	zassert_equal(size, clen, "Unexpected ciphertext length");
-	rc = ascon128_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen, associated_data, 4, nonce, key);
+	rc = ascon128_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen, associated_data, 4,
+				   nonce, key);
 	zassert_equal(0, rc, "Decryption failed");
 	zassert_equal(size, mlen, "Unexpected decrypt length");
 	zassert_mem_equal(plaintext, decrypted, size, "Decrypted does not equal input");
@@ -122,17 +124,20 @@ ZTEST(ascon, test_ascon128_unaligned)
 
 	for (int i = 1; i < 8; i++) {
 		/* Encrypt the payload */
-		rc = ascon128_aead_encrypt(ciphertext + i, &clen, plaintext + i, size, associated_data + i,
-					   sizeof(associated_data), tag + i, nonce + i, key + i);
+		rc = ascon128_aead_encrypt(ciphertext + i, &clen, plaintext + i, size,
+					   associated_data + i, sizeof(associated_data), tag + i,
+					   nonce + i, key + i);
 		zassert_equal(0, rc, "Encryption failed");
 		zassert_equal(size, clen, "Unexpected ciphertext length");
 
 		/* Decrypt the payload */
-		rc = ascon128_aead_decrypt(decrypted + i, &mlen, tag + i, ciphertext + i, clen, associated_data + i,
-					   sizeof(associated_data), nonce + i, key + i);
+		rc = ascon128_aead_decrypt(decrypted + i, &mlen, tag + i, ciphertext + i, clen,
+					   associated_data + i, sizeof(associated_data), nonce + i,
+					   key + i);
 		zassert_equal(0, rc, "Decryption failed");
 		zassert_equal(size, mlen, "Unexpected decrypt length");
-		zassert_mem_equal(plaintext + i, decrypted + i, size, "Decrypted does not equal input");
+		zassert_mem_equal(plaintext + i, decrypted + i, size,
+				  "Decrypted does not equal input");
 	}
 }
 
@@ -154,35 +159,35 @@ ZTEST(ascon, test_ascon128a)
 
 		/* Ciphertext error */
 		ciphertext[0]++;
-		rc = ascon128a_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen, associated_data,
-					    sizeof(associated_data), nonce, key);
+		rc = ascon128a_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen,
+					    associated_data, sizeof(associated_data), nonce, key);
 		zassert_equal(-1, rc, "Decryption did not fail");
 		ciphertext[0]--;
 
 		/* Tag error */
 		tag[0]++;
-		rc = ascon128a_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen, associated_data,
-					    sizeof(associated_data), nonce, key);
+		rc = ascon128a_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen,
+					    associated_data, sizeof(associated_data), nonce, key);
 		zassert_equal(-1, rc, "Decryption did not fail");
 		tag[0]--;
 
 		/* Key error */
 		key[0]++;
-		rc = ascon128a_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen, associated_data,
-					    sizeof(associated_data), nonce, key);
+		rc = ascon128a_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen,
+					    associated_data, sizeof(associated_data), nonce, key);
 		zassert_equal(-1, rc, "Decryption did not fail");
 		key[0]--;
 
 		/* Associated data error */
 		associated_data[0]++;
-		rc = ascon128a_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen, associated_data,
-					    sizeof(associated_data), nonce, key);
+		rc = ascon128a_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen,
+					    associated_data, sizeof(associated_data), nonce, key);
 		zassert_equal(-1, rc, "Decryption did not fail");
 		associated_data[0]--;
 
 		/* Decrypt the payload */
-		rc = ascon128a_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen, associated_data,
-					    sizeof(associated_data), nonce, key);
+		rc = ascon128a_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen,
+					    associated_data, sizeof(associated_data), nonce, key);
 		zassert_equal(0, rc, "Decryption failed");
 		zassert_equal(size, mlen, "Unexpected decrypt length");
 		zassert_mem_equal(plaintext, decrypted, size, "Decrypted does not equal input");
@@ -208,10 +213,12 @@ ZTEST(ascon, test_ascon128a_associated_data)
 	zassert_mem_equal(plaintext, decrypted, size, "Decrypted does not equal input");
 
 	/* Small associated data */
-	rc = ascon128a_aead_encrypt(ciphertext, &clen, plaintext, size, associated_data, 4, tag, nonce, key);
+	rc = ascon128a_aead_encrypt(ciphertext, &clen, plaintext, size, associated_data, 4, tag,
+				    nonce, key);
 	zassert_equal(0, rc, "Encryption failed");
 	zassert_equal(size, clen, "Unexpected ciphertext length");
-	rc = ascon128a_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen, associated_data, 4, nonce, key);
+	rc = ascon128a_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen, associated_data, 4,
+				    nonce, key);
 	zassert_equal(0, rc, "Decryption failed");
 	zassert_equal(size, mlen, "Unexpected decrypt length");
 	zassert_mem_equal(plaintext, decrypted, size, "Decrypted does not equal input");
@@ -228,17 +235,20 @@ ZTEST(ascon, test_ascon128a_unaligned)
 
 	for (int i = 1; i < 8; i++) {
 		/* Encrypt the payload */
-		rc = ascon128a_aead_encrypt(ciphertext + i, &clen, plaintext + i, size, associated_data + i,
-					    sizeof(associated_data), tag + i, nonce + i, key + i);
+		rc = ascon128a_aead_encrypt(ciphertext + i, &clen, plaintext + i, size,
+					    associated_data + i, sizeof(associated_data), tag + i,
+					    nonce + i, key + i);
 		zassert_equal(0, rc, "Encryption failed");
 		zassert_equal(size, clen, "Unexpected ciphertext length");
 
 		/* Decrypt the payload */
-		rc = ascon128a_aead_decrypt(decrypted + i, &mlen, tag + i, ciphertext + i, clen, associated_data + i,
-					    sizeof(associated_data), nonce + i, key + i);
+		rc = ascon128a_aead_decrypt(decrypted + i, &mlen, tag + i, ciphertext + i, clen,
+					    associated_data + i, sizeof(associated_data), nonce + i,
+					    key + i);
 		zassert_equal(0, rc, "Decryption failed");
 		zassert_equal(size, mlen, "Unexpected decrypt length");
-		zassert_mem_equal(plaintext + i, decrypted + i, size, "Decrypted does not equal input");
+		zassert_mem_equal(plaintext + i, decrypted + i, size,
+				  "Decrypted does not equal input");
 	}
 }
 
@@ -260,35 +270,35 @@ ZTEST(ascon, test_ascon80pq)
 
 		/* Ciphertext error */
 		ciphertext[0]++;
-		rc = ascon80pq_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen, associated_data,
-					    sizeof(associated_data), nonce, key);
+		rc = ascon80pq_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen,
+					    associated_data, sizeof(associated_data), nonce, key);
 		zassert_equal(-1, rc, "Decryption did not fail");
 		ciphertext[0]--;
 
 		/* Tag error */
 		tag[0]++;
-		rc = ascon80pq_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen, associated_data,
-					    sizeof(associated_data), nonce, key);
+		rc = ascon80pq_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen,
+					    associated_data, sizeof(associated_data), nonce, key);
 		zassert_equal(-1, rc, "Decryption did not fail");
 		tag[0]--;
 
 		/* Key error */
 		key[0]++;
-		rc = ascon80pq_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen, associated_data,
-					    sizeof(associated_data), nonce, key);
+		rc = ascon80pq_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen,
+					    associated_data, sizeof(associated_data), nonce, key);
 		zassert_equal(-1, rc, "Decryption did not fail");
 		key[0]--;
 
 		/* Associated data error */
 		associated_data[0]++;
-		rc = ascon80pq_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen, associated_data,
-					    sizeof(associated_data), nonce, key);
+		rc = ascon80pq_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen,
+					    associated_data, sizeof(associated_data), nonce, key);
 		zassert_equal(-1, rc, "Decryption did not fail");
 		associated_data[0]--;
 
 		/* Decrypt the payload */
-		rc = ascon80pq_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen, associated_data,
-					    sizeof(associated_data), nonce, key);
+		rc = ascon80pq_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen,
+					    associated_data, sizeof(associated_data), nonce, key);
 		zassert_equal(0, rc, "Decryption failed");
 		zassert_equal(size, mlen, "Unexpected decrypt length");
 		zassert_mem_equal(plaintext, decrypted, size, "Decrypted does not equal input");
@@ -314,10 +324,12 @@ ZTEST(ascon, test_ascon80pq_associated_data)
 	zassert_mem_equal(plaintext, decrypted, size, "Decrypted does not equal input");
 
 	/* Small associated data */
-	rc = ascon80pq_aead_encrypt(ciphertext, &clen, plaintext, size, associated_data, 4, tag, nonce, key);
+	rc = ascon80pq_aead_encrypt(ciphertext, &clen, plaintext, size, associated_data, 4, tag,
+				    nonce, key);
 	zassert_equal(0, rc, "Encryption failed");
 	zassert_equal(size, clen, "Unexpected ciphertext length");
-	rc = ascon80pq_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen, associated_data, 4, nonce, key);
+	rc = ascon80pq_aead_decrypt(decrypted, &mlen, tag, ciphertext, clen, associated_data, 4,
+				    nonce, key);
 	zassert_equal(0, rc, "Decryption failed");
 	zassert_equal(size, mlen, "Unexpected decrypt length");
 	zassert_mem_equal(plaintext, decrypted, size, "Decrypted does not equal input");
@@ -334,17 +346,20 @@ ZTEST(ascon, test_ascon80pq_unaligned)
 
 	for (int i = 1; i < 8; i++) {
 		/* Encrypt the payload */
-		rc = ascon80pq_aead_encrypt(ciphertext + i, &clen, plaintext + i, size, associated_data + i,
-					    sizeof(associated_data), tag + i, nonce + i, key + i);
+		rc = ascon80pq_aead_encrypt(ciphertext + i, &clen, plaintext + i, size,
+					    associated_data + i, sizeof(associated_data), tag + i,
+					    nonce + i, key + i);
 		zassert_equal(0, rc, "Encryption failed");
 		zassert_equal(size, clen, "Unexpected ciphertext length");
 
 		/* Decrypt the payload */
-		rc = ascon80pq_aead_decrypt(decrypted + i, &mlen, tag + i, ciphertext + i, clen, associated_data + i,
-					    sizeof(associated_data), nonce + i, key + i);
+		rc = ascon80pq_aead_decrypt(decrypted + i, &mlen, tag + i, ciphertext + i, clen,
+					    associated_data + i, sizeof(associated_data), nonce + i,
+					    key + i);
 		zassert_equal(0, rc, "Decryption failed");
 		zassert_equal(size, mlen, "Unexpected decrypt length");
-		zassert_mem_equal(plaintext + i, decrypted + i, size, "Decrypted does not equal input");
+		zassert_mem_equal(plaintext + i, decrypted + i, size,
+				  "Decrypted does not equal input");
 	}
 }
 

--- a/tests/lib/reboot/src/main.c
+++ b/tests/lib/reboot/src/main.c
@@ -89,10 +89,12 @@ ZTEST(infuse_reboot, test_reboot)
 		/* Uptime should be roughly correct */
 		zassert_within(3, reboot_state.uptime, 1);
 		/* Program counter should be somewhere in civil_time_set_reference */
-		zassert_between_inclusive(reboot_state.param_1.program_counter, (uintptr_t)civil_time_set_reference,
+		zassert_between_inclusive(reboot_state.param_1.program_counter,
+					  (uintptr_t)civil_time_set_reference,
 					  (uintptr_t)civil_time_set_reference + 64);
 		/* Link register should be somewhere in null_dereference */
-		zassert_between_inclusive(reboot_state.param_2.link_register, (uintptr_t)null_dereference,
+		zassert_between_inclusive(reboot_state.param_2.link_register,
+					  (uintptr_t)null_dereference,
 					  (uintptr_t)null_dereference + 64);
 		/* No time knowledge again */
 		zassert_equal(TIME_SOURCE_NONE, reboot_state.civil_time_source);
@@ -132,7 +134,8 @@ ZTEST(infuse_reboot, test_reboot)
 		zassert_true(reboot_state.uptime >= 3);
 		/* Time reference should be valid and about half a second after the reference */
 		zassert_equal(TIME_SOURCE_NTP, reboot_state.civil_time_source);
-		zassert_within(reboot_state.civil_time, time_2025 + INFUSE_CIVIL_TIME_TICKS_PER_SEC / 2,
+		zassert_within(reboot_state.civil_time,
+			       time_2025 + INFUSE_CIVIL_TIME_TICKS_PER_SEC / 2,
 			       INFUSE_CIVIL_TIME_TICKS_PER_SEC / 10);
 		/* Test sequence complete */
 		break;
@@ -152,8 +155,8 @@ void *test_init(void)
 
 	/* Get current reboot count */
 	if (rc == 0) {
-		rc = kv_store_read_fallback(KV_KEY_REBOOTS, &reboot, sizeof(reboot), &reboot_fallback,
-					    sizeof(reboot_fallback));
+		rc = kv_store_read_fallback(KV_KEY_REBOOTS, &reboot, sizeof(reboot),
+					    &reboot_fallback, sizeof(reboot_fallback));
 		if (rc == sizeof(reboot)) {
 			/* Increment reboot counter */
 			reboot.count += 1;

--- a/tests/net/auto_sntp/src/main.c
+++ b/tests/net/auto_sntp/src/main.c
@@ -26,7 +26,8 @@ static int kv_init(void)
 
 SYS_INIT(kv_init, POST_KERNEL, 60);
 
-static void l4_event_handler(struct net_mgmt_event_callback *cb, uint32_t mgmt_event, struct net_if *iface)
+static void l4_event_handler(struct net_mgmt_event_callback *cb, uint32_t mgmt_event,
+			     struct net_if *iface)
 {
 	ARG_UNUSED(iface);
 	ARG_UNUSED(cb);
@@ -97,11 +98,13 @@ ZTEST(auto_sntp, test_boot)
 	/* Wait a while, manually set the reference to reset the resync age */
 	reference.local = k_uptime_ticks();
 	reference.ref = 10000000;
-	zassert_equal(-EAGAIN, k_sem_take(&time_ref_updated, K_SECONDS(CONFIG_SNTP_AUTO_RESYNC_AGE - 1)));
+	zassert_equal(-EAGAIN,
+		      k_sem_take(&time_ref_updated, K_SECONDS(CONFIG_SNTP_AUTO_RESYNC_AGE - 1)));
 	zassert_equal(0, civil_time_set_reference(TIME_SOURCE_INVALID, &reference));
 
 	/* Ensure the time sync was delayed by the previous reference */
-	zassert_equal(-EAGAIN, k_sem_take(&time_ref_updated, K_SECONDS(CONFIG_SNTP_AUTO_RESYNC_AGE - 1)));
+	zassert_equal(-EAGAIN,
+		      k_sem_take(&time_ref_updated, K_SECONDS(CONFIG_SNTP_AUTO_RESYNC_AGE - 1)));
 	zassert_equal(0, k_sem_take(&time_ref_updated, K_SECONDS(2)));
 
 #ifdef CONFIG_NET_NATIVE_OFFLOADED_SOCKETS
@@ -109,7 +112,8 @@ ZTEST(auto_sntp, test_boot)
 	zassert_true(net_if_ipv4_addr_rm(iface, &addr));
 
 	/* No more callbacks */
-	zassert_equal(-EAGAIN, k_sem_take(&time_ref_updated, K_SECONDS(CONFIG_SNTP_AUTO_RESYNC_AGE + 1)));
+	zassert_equal(-EAGAIN,
+		      k_sem_take(&time_ref_updated, K_SECONDS(CONFIG_SNTP_AUTO_RESYNC_AGE + 1)));
 
 	/* Set time sync while disconnected */
 	k_sleep(K_MSEC(500));

--- a/tests/subsys/data_logger/backends/epacket/src/main.c
+++ b/tests/subsys/data_logger/backends/epacket/src/main.c
@@ -40,7 +40,8 @@ ZTEST(data_logger_epacket, test_block_read)
 	/* Reading from ePacket should always fail */
 	zassert_equal(-ENOTSUP, data_logger_block_read(logger, 0, 0, buffer, sizeof(buffer)));
 	zassert_equal(-ENOTSUP, data_logger_block_read(logger, 10, 0, buffer, sizeof(buffer)));
-	zassert_equal(-ENOTSUP, data_logger_block_read(logger, UINT32_MAX, 0, buffer, sizeof(buffer)));
+	zassert_equal(-ENOTSUP,
+		      data_logger_block_read(logger, UINT32_MAX, 0, buffer, sizeof(buffer)));
 }
 
 ZTEST(data_logger_epacket, test_block_write_error)

--- a/tests/subsys/data_logger/backends/persistent/src/main.c
+++ b/tests/subsys/data_logger/backends/persistent/src/main.c
@@ -151,7 +151,8 @@ ZTEST(data_logger_flash_map, test_init_all_written_with_end_erase)
 		memset(flash_buffer_end - state.erase_unit, 0x04, state.block_size * i);
 		zassert_equal(0, data_logger_init(logger));
 		data_logger_get_state(logger, &state);
-		zassert_equal(0x04 * state.physical_blocks - blocks_in_erase + i, state.current_block);
+		zassert_equal(0x04 * state.physical_blocks - blocks_in_erase + i,
+			      state.current_block);
 		zassert_equal(0x03 * state.physical_blocks, state.earliest_block);
 	}
 }
@@ -166,8 +167,10 @@ ZTEST(data_logger_flash_map, test_write_errors)
 	zassert_equal(0, data_logger_init(logger));
 	data_logger_get_state(logger, &state);
 
-	zassert_equal(-EINVAL, data_logger_block_write(logger, 0x10, input_buffer, state.block_size + 1));
-	zassert_equal(-ENOMEM, data_logger_block_write(logger, 0x10, input_buffer, state.block_size));
+	zassert_equal(-EINVAL,
+		      data_logger_block_write(logger, 0x10, input_buffer, state.block_size + 1));
+	zassert_equal(-ENOMEM,
+		      data_logger_block_write(logger, 0x10, input_buffer, state.block_size));
 }
 
 ZTEST(data_logger_flash_map, test_read_errors)
@@ -181,19 +184,21 @@ ZTEST(data_logger_flash_map, test_read_errors)
 	data_logger_get_state(logger, &state);
 
 	/* Start of logger */
-	zassert_equal(-ENOENT, data_logger_block_read(logger, 0, 0, output_buffer, state.block_size));
-	/* Just before start of data */
-	zassert_equal(-ENOENT, data_logger_block_read(logger, 0x03 * state.physical_blocks - 1, 0, output_buffer,
-						      state.block_size));
-	/* Just after end of data */
 	zassert_equal(-ENOENT,
-		      data_logger_block_read(logger, 0x04 * state.physical_blocks, 0, output_buffer, state.block_size));
-	/* Reading from valid data into invalid data */
-	zassert_equal(-ENOENT, data_logger_block_read(logger, 0x05 * state.physical_blocks - 1, 0, output_buffer,
-						      2 * state.block_size));
-	/* Invalid block offset */
-	zassert_equal(-ENOENT, data_logger_block_read(logger, 0x03 * state.physical_blocks, state.block_size,
+		      data_logger_block_read(logger, 0, 0, output_buffer, state.block_size));
+	/* Just before start of data */
+	zassert_equal(-ENOENT, data_logger_block_read(logger, 0x03 * state.physical_blocks - 1, 0,
 						      output_buffer, state.block_size));
+	/* Just after end of data */
+	zassert_equal(-ENOENT, data_logger_block_read(logger, 0x04 * state.physical_blocks, 0,
+						      output_buffer, state.block_size));
+	/* Reading from valid data into invalid data */
+	zassert_equal(-ENOENT, data_logger_block_read(logger, 0x05 * state.physical_blocks - 1, 0,
+						      output_buffer, 2 * state.block_size));
+	/* Invalid block offset */
+	zassert_equal(-ENOENT,
+		      data_logger_block_read(logger, 0x03 * state.physical_blocks, state.block_size,
+					     output_buffer, state.block_size));
 }
 
 ZTEST(data_logger_flash_map, test_read_wrap)
@@ -210,19 +215,21 @@ ZTEST(data_logger_flash_map, test_read_wrap)
 	zassert_equal(state.physical_blocks / 2, state.earliest_block);
 
 	/* Read across block boundary */
-	zassert_equal(0, data_logger_block_read(logger, state.physical_blocks, 200, output_buffer, state.block_size));
+	zassert_equal(0, data_logger_block_read(logger, state.physical_blocks, 200, output_buffer,
+						state.block_size));
 	memset(input_buffer, 0x02, state.block_size);
 	zassert_mem_equal(input_buffer, output_buffer, state.block_size);
 
 	/* Read across wrap around boundary */
-	zassert_equal(
-		0, data_logger_block_read(logger, state.physical_blocks - 1, 0, output_buffer, 2 * state.block_size));
+	zassert_equal(0, data_logger_block_read(logger, state.physical_blocks - 1, 0, output_buffer,
+						2 * state.block_size));
 	memset(input_buffer, 0x01, state.block_size);
 	memset(input_buffer + state.block_size, 0x02, state.block_size);
 	zassert_mem_equal(input_buffer, output_buffer, 2 * state.block_size);
 
 	/* Read across wrap around boundary with offset */
-	zassert_equal(0, data_logger_block_read(logger, state.physical_blocks - 1, 500, output_buffer, 20));
+	zassert_equal(0, data_logger_block_read(logger, state.physical_blocks - 1, 500,
+						output_buffer, 20));
 	memset(input_buffer, 0x01, state.block_size - 500);
 	memset(input_buffer + state.block_size - 500, 0x02, 20 - (state.block_size - 500));
 	zassert_mem_equal(input_buffer, output_buffer, 20);
@@ -230,7 +237,8 @@ ZTEST(data_logger_flash_map, test_read_wrap)
 
 static void test_sequence(bool reinit)
 {
-	const struct flash_parameters *params = flash_get_parameters(DEVICE_DT_GET(DT_NODELABEL(sim_flash)));
+	const struct flash_parameters *params =
+		flash_get_parameters(DEVICE_DT_GET(DT_NODELABEL(sim_flash)));
 	const struct device *logger = DEVICE_DT_GET(DT_NODELABEL(data_logger_flash));
 	struct data_logger_persistent_block_header *header = (void *)output_buffer;
 	struct data_logger_state state;
@@ -246,14 +254,17 @@ static void test_sequence(bool reinit)
 		type = (i % 10) + 1;
 		memset(input_buffer, i, sizeof(input_buffer));
 		/* Write block to logger */
-		zassert_equal(0, data_logger_block_write(logger, type, input_buffer, state.block_size));
+		zassert_equal(
+			0, data_logger_block_write(logger, type, input_buffer, state.block_size));
 		data_logger_get_state(logger, &state);
 		zassert_equal(i + 1, state.current_block);
 		/* Read block back from logger and check against input */
-		zassert_equal(0, data_logger_block_read(logger, i, 0, output_buffer, state.block_size));
+		zassert_equal(
+			0, data_logger_block_read(logger, i, 0, output_buffer, state.block_size));
 		zassert_equal(type, header->block_type);
 		zassert_equal((i / state.physical_blocks) + 1, header->block_wrap);
-		zassert_mem_equal(input_buffer + sizeof(*header), output_buffer + sizeof(*header), sizeof(*header));
+		zassert_mem_equal(input_buffer + sizeof(*header), output_buffer + sizeof(*header),
+				  sizeof(*header));
 
 		/* Reinit logger and validate state not lost */
 		if (reinit) {
@@ -274,7 +285,8 @@ ZTEST(data_logger_flash_map, test_standard_operation)
 
 static bool test_data_init(const void *global_state)
 {
-	flash_buffer = flash_simulator_get_memory(DEVICE_DT_GET(DT_NODELABEL(sim_flash)), &flash_buffer_size);
+	flash_buffer = flash_simulator_get_memory(DEVICE_DT_GET(DT_NODELABEL(sim_flash)),
+						  &flash_buffer_size);
 	return true;
 }
 

--- a/tests/subsys/data_logger/high_level/tdf_multi/src/main.c
+++ b/tests/subsys/data_logger/high_level/tdf_multi/src/main.c
@@ -60,7 +60,8 @@ ZTEST(tdf_data_logger_multi, test_standard)
 	validate_loggers(expected_flash, expected_epacket);
 
 	/* Add to both */
-	tdf_data_logger_log(TDF_DATA_LOGGER_FLASH | TDF_DATA_LOGGER_UDP, TDF_RANDOM, 17, 0, tdf_data);
+	tdf_data_logger_log(TDF_DATA_LOGGER_FLASH | TDF_DATA_LOGGER_UDP, TDF_RANDOM, 17, 0,
+			    tdf_data);
 	validate_loggers(expected_flash, expected_epacket);
 
 	/* Flush both */

--- a/tests/subsys/data_logger/high_level/tdf_persistent/src/main.c
+++ b/tests/subsys/data_logger/high_level/tdf_persistent/src/main.c
@@ -139,7 +139,8 @@ void data_logger_reset(void *fixture)
 
 static bool test_data_init(const void *global_state)
 {
-	flash_buffer = flash_simulator_get_memory(DEVICE_DT_GET(DT_NODELABEL(sim_flash)), &flash_buffer_size);
+	flash_buffer = flash_simulator_get_memory(DEVICE_DT_GET(DT_NODELABEL(sim_flash)),
+						  &flash_buffer_size);
 	return true;
 }
 

--- a/tests/subsys/epacket/interfaces/serial/src/main.c
+++ b/tests/subsys/epacket/interfaces/serial/src/main.c
@@ -197,7 +197,8 @@ ZTEST(epacket_serial, test_sequence)
 
 	for (int i = 0; i < ARRAY_SIZE(seqs); i++) {
 		iter_auth = i % 2 ? EPACKET_AUTH_DEVICE : EPACKET_AUTH_NETWORK;
-		extra_flags = i % 2 ? EPACKET_FLAGS_ENCRYPTION_DEVICE : EPACKET_FLAGS_ENCRYPTION_NETWORK;
+		extra_flags =
+			i % 2 ? EPACKET_FLAGS_ENCRYPTION_DEVICE : EPACKET_FLAGS_ENCRYPTION_NETWORK;
 		/* Construct buffer */
 		tx = epacket_alloc_tx(K_NO_WAIT);
 		zassert_not_null(tx);

--- a/tests/subsys/epacket/keys/src/main.c
+++ b/tests/subsys/epacket/keys/src/main.c
@@ -111,7 +111,8 @@ ZTEST(epacket_keys, test_key_derive)
 	/* Rotation gives different keys */
 	for (int i = 1; i < 100; i++) {
 		rc1 = epacket_key_derive(EPACKET_KEY_DEVICE, info, strlen(info), rotation, &id_1);
-		rc2 = epacket_key_derive(EPACKET_KEY_DEVICE, info, strlen(info), rotation + i, &id_2);
+		rc2 = epacket_key_derive(EPACKET_KEY_DEVICE, info, strlen(info), rotation + i,
+					 &id_2);
 
 		zassert_equal(0, rc1, "Derivation failed");
 		zassert_equal(0, rc2, "Derivation failed");

--- a/tests/subsys/kv_store/src/main.c
+++ b/tests/subsys/kv_store/src/main.c
@@ -27,7 +27,8 @@ ZTEST(kv_store, test_init_failure)
 
 	/* Write all the flash to 0 */
 	for (int i = 0; i < NVS_PARTITION_SIZE; i += sizeof(zeroes)) {
-		zassert_equal(0, flash_write(dev, NVS_PARTITION_OFFSET + i, zeroes, sizeof(zeroes)));
+		zassert_equal(0,
+			      flash_write(dev, NVS_PARTITION_OFFSET + i, zeroes, sizeof(zeroes)));
 	}
 
 	/* Ensure init still succeeds */
@@ -62,7 +63,8 @@ ZTEST(kv_store, test_disabled_key)
 
 	rc = kv_store_read(KV_KEY_FIXED_LOCATION, &location, sizeof(location));
 	zassert_equal(-EACCES, rc);
-	rc = kv_store_read_fallback(KV_KEY_FIXED_LOCATION, &location, sizeof(location), &fallback, sizeof(fallback));
+	rc = kv_store_read_fallback(KV_KEY_FIXED_LOCATION, &location, sizeof(location), &fallback,
+				    sizeof(fallback));
 	zassert_equal(-EACCES, rc);
 	rc = kv_store_write(KV_KEY_FIXED_LOCATION, &location, sizeof(location));
 	zassert_equal(-EACCES, rc);
@@ -131,7 +133,8 @@ ZTEST(kv_store, test_read_fallback)
 	ssize_t rc;
 
 	/* Initial fallback read */
-	rc = kv_store_read_fallback(KV_KEY_REBOOTS, &reboots, sizeof(reboots), &fallback, sizeof(fallback));
+	rc = kv_store_read_fallback(KV_KEY_REBOOTS, &reboots, sizeof(reboots), &fallback,
+				    sizeof(fallback));
 	zassert_equal(sizeof(reboots), rc);
 	zassert_equal(100, reboots.count);
 
@@ -141,7 +144,8 @@ ZTEST(kv_store, test_read_fallback)
 	zassert_equal(sizeof(reboots), rc);
 
 	/* Second fallback read */
-	rc = kv_store_read_fallback(KV_KEY_REBOOTS, &reboots, sizeof(reboots), &fallback, sizeof(fallback));
+	rc = kv_store_read_fallback(KV_KEY_REBOOTS, &reboots, sizeof(reboots), &fallback,
+				    sizeof(fallback));
 	zassert_equal(sizeof(reboots), rc);
 	zassert_equal(110, reboots.count);
 }
@@ -205,7 +209,8 @@ ZTEST(kv_store, test_callbacks)
 
 	/* Callback run on fallback */
 	ctx.key = -1;
-	(void)kv_store_read_fallback(KV_KEY_REBOOTS, &reboots, sizeof(reboots), &fallback, sizeof(fallback));
+	(void)kv_store_read_fallback(KV_KEY_REBOOTS, &reboots, sizeof(reboots), &fallback,
+				     sizeof(fallback));
 	zassert_equal(KV_KEY_REBOOTS, ctx.key);
 	zassert_not_null(ctx.data);
 	zassert_equal(sizeof(fallback), ctx.data_len);

--- a/tests/subsys/rpc/commands/fault/src/main.c
+++ b/tests/subsys/rpc/commands/fault/src/main.c
@@ -92,7 +92,8 @@ ZTEST(rpc_command_fault, test_does_fault)
 		/* Validate previous reboot information */
 		rc = infuse_common_boot_last_reboot(&reboot_state);
 		zassert_equal(0, rc);
-		zassert_equal((enum infuse_reboot_reason)K_ERR_ARM_MEM_DATA_ACCESS, reboot_state.reason);
+		zassert_equal((enum infuse_reboot_reason)K_ERR_ARM_MEM_DATA_ACCESS,
+			      reboot_state.reason);
 		/* Divide by 0 */
 		send_fault_command(0, K_ERR_ARM_USAGE_DIV_0);
 		k_sleep(K_MSEC(10));
@@ -102,17 +103,20 @@ ZTEST(rpc_command_fault, test_does_fault)
 		/* Validate previous reboot information */
 		rc = infuse_common_boot_last_reboot(&reboot_state);
 		zassert_equal(0, rc);
-		zassert_equal((enum infuse_reboot_reason)K_ERR_ARM_USAGE_DIV_0, reboot_state.reason);
+		zassert_equal((enum infuse_reboot_reason)K_ERR_ARM_USAGE_DIV_0,
+			      reboot_state.reason);
 		/* Unaligned memory access */
 		send_fault_command(0, K_ERR_ARM_USAGE_UNDEFINED_INSTRUCTION);
 		k_sleep(K_MSEC(10));
-		zassert_unreachable("K_ERR_ARM_USAGE_UNDEFINED_INSTRUCTION did not trigger exception");
+		zassert_unreachable(
+			"K_ERR_ARM_USAGE_UNDEFINED_INSTRUCTION did not trigger exception");
 		break;
 	case 5:
 		/* Validate previous reboot information */
 		rc = infuse_common_boot_last_reboot(&reboot_state);
 		zassert_equal(0, rc);
-		zassert_equal((enum infuse_reboot_reason)K_ERR_ARM_USAGE_UNDEFINED_INSTRUCTION, reboot_state.reason);
+		zassert_equal((enum infuse_reboot_reason)K_ERR_ARM_USAGE_UNDEFINED_INSTRUCTION,
+			      reboot_state.reason);
 		/* Unaligned memory access */
 		send_fault_command(0, K_ERR_ARM_MEM_INSTRUCTION_ACCESS);
 		k_sleep(K_MSEC(10));
@@ -122,7 +126,8 @@ ZTEST(rpc_command_fault, test_does_fault)
 		/* Validate previous reboot information */
 		rc = infuse_common_boot_last_reboot(&reboot_state);
 		zassert_equal(0, rc);
-		zassert_equal((enum infuse_reboot_reason)K_ERR_ARM_MEM_INSTRUCTION_ACCESS, reboot_state.reason);
+		zassert_equal((enum infuse_reboot_reason)K_ERR_ARM_MEM_INSTRUCTION_ACCESS,
+			      reboot_state.reason);
 		/* Unknown fault code */
 		send_fault_command(0x123456, 255);
 		expect_fault_response(0x123456, -EINVAL);

--- a/tests/subsys/rpc/commands/kv_read/src/main.c
+++ b/tests/subsys/rpc/commands/kv_read/src/main.c
@@ -18,7 +18,8 @@
 #include <infuse/epacket/packet.h>
 #include <infuse/epacket/interface/epacket_dummy.h>
 
-static void send_kv_read_command(uint32_t request_id, uint16_t *keys, uint8_t req_num, uint8_t actual_num)
+static void send_kv_read_command(uint32_t request_id, uint16_t *keys, uint8_t req_num,
+				 uint8_t actual_num)
 {
 	const struct device *epacket_dummy = DEVICE_DT_GET(DT_NODELABEL(epacket_dummy));
 	struct epacket_dummy_frame header = {
@@ -86,7 +87,8 @@ ZTEST(rpc_command_kv_read, test_single)
 	send_kv_read_command(0x1234, &key, 1, 1);
 	rsp = expect_kv_read_response(0x1234, 0);
 	response = (void *)rsp->data;
-	zassert_equal(sizeof(struct rpc_kv_read_response) + sizeof(struct rpc_struct_kv_store_value) + sizeof(uint32_t),
+	zassert_equal(sizeof(struct rpc_kv_read_response) +
+			      sizeof(struct rpc_struct_kv_store_value) + sizeof(uint32_t),
 		      rsp->len);
 	zassert_equal(KV_KEY_REBOOTS, response->values[0].id);
 	zassert_equal(sizeof(uint32_t), response->values[0].len);
@@ -98,7 +100,9 @@ ZTEST(rpc_command_kv_read, test_single)
 	send_kv_read_command(1000, &key, 1, 1);
 	rsp = expect_kv_read_response(1000, 0);
 	response = (void *)rsp->data;
-	zassert_equal(sizeof(struct rpc_kv_read_response) + sizeof(struct rpc_struct_kv_store_value), rsp->len);
+	zassert_equal(sizeof(struct rpc_kv_read_response) +
+			      sizeof(struct rpc_struct_kv_store_value),
+		      rsp->len);
 	zassert_equal(KV_KEY_WIFI_SSID, response->values[0].id);
 	zassert_equal(-ENOENT, response->values[0].len);
 	net_buf_unref(rsp);
@@ -108,7 +112,9 @@ ZTEST(rpc_command_kv_read, test_single)
 	send_kv_read_command(1001, &key, 1, 1);
 	rsp = expect_kv_read_response(1001, 0);
 	response = (void *)rsp->data;
-	zassert_equal(sizeof(struct rpc_kv_read_response) + sizeof(struct rpc_struct_kv_store_value), rsp->len);
+	zassert_equal(sizeof(struct rpc_kv_read_response) +
+			      sizeof(struct rpc_struct_kv_store_value),
+		      rsp->len);
 	zassert_equal(0x4567, response->values[0].id);
 	zassert_equal(-EACCES, response->values[0].len);
 	net_buf_unref(rsp);

--- a/tests/subsys/rpc/commands/kv_write/src/main.c
+++ b/tests/subsys/rpc/commands/kv_write/src/main.c
@@ -36,10 +36,12 @@ static void send_kv_write_command(uint32_t request_id, struct net_buf_simple *va
 	};
 
 	/* Push command at RPC server */
-	epacket_dummy_receive_extra(epacket_dummy, &header, &params, sizeof(params), values->data, values->len);
+	epacket_dummy_receive_extra(epacket_dummy, &header, &params, sizeof(params), values->data,
+				    values->len);
 }
 
-static struct net_buf *expect_kv_write_response(uint32_t request_id, int16_t rc, uint8_t expected_responses)
+static struct net_buf *expect_kv_write_response(uint32_t request_id, int16_t rc,
+						uint8_t expected_responses)
 {
 	struct k_fifo *response_queue = epacket_dummmy_transmit_fifo_get();
 	struct rpc_kv_write_response *response;

--- a/tests/subsys/rpc/server/src/main.c
+++ b/tests/subsys/rpc/server/src/main.c
@@ -115,7 +115,8 @@ ZTEST(rpc_server, test_auth_level)
 	/* ECHO with EPACKET_AUTH_DEVICE */
 	req_header->command_id = RPC_ID_ECHO;
 	header.auth = EPACKET_AUTH_DEVICE;
-	epacket_dummy_receive(epacket_dummy, &header, payload, sizeof(struct rpc_echo_request) + sizeof(payload));
+	epacket_dummy_receive(epacket_dummy, &header, payload,
+			      sizeof(struct rpc_echo_request) + sizeof(payload));
 	tx = net_buf_get(tx_fifo, K_MSEC(10));
 	zassert_not_null(tx);
 	tx_header = (void *)tx->data;
@@ -128,7 +129,8 @@ ZTEST(rpc_server, test_auth_level)
 	/* ECHO with EPACKET_AUTH_NETWORK */
 	req_header->command_id = RPC_ID_ECHO;
 	header.auth = EPACKET_AUTH_NETWORK;
-	epacket_dummy_receive(epacket_dummy, &header, payload, sizeof(struct rpc_echo_request) + sizeof(payload));
+	epacket_dummy_receive(epacket_dummy, &header, payload,
+			      sizeof(struct rpc_echo_request) + sizeof(payload));
 	tx = net_buf_get(tx_fifo, K_MSEC(10));
 	zassert_not_null(tx);
 	tx_header = (void *)tx->data;
@@ -141,7 +143,8 @@ ZTEST(rpc_server, test_auth_level)
 	/* DATA_SENDER with EPACKET_AUTH_NETWORK */
 	req_header->command_id = RPC_ID_DATA_SENDER;
 	header.auth = EPACKET_AUTH_NETWORK;
-	epacket_dummy_receive(epacket_dummy, &header, payload, sizeof(struct rpc_echo_request) + sizeof(payload));
+	epacket_dummy_receive(epacket_dummy, &header, payload,
+			      sizeof(struct rpc_echo_request) + sizeof(payload));
 	tx = net_buf_get(tx_fifo, K_MSEC(10));
 	zassert_not_null(tx);
 	tx_header = (void *)tx->data;
@@ -176,7 +179,8 @@ ZTEST(rpc_server, test_echo_response)
 		req_header->command_id = RPC_ID_ECHO;
 		req_header->request_id = request_id;
 
-		epacket_dummy_receive(epacket_dummy, &header, payload, sizeof(struct rpc_echo_request) + lens[i]);
+		epacket_dummy_receive(epacket_dummy, &header, payload,
+				      sizeof(struct rpc_echo_request) + lens[i]);
 
 		tx = net_buf_get(tx_fifo, K_MSEC(10));
 		zassert_not_null(tx);
@@ -219,7 +223,8 @@ static void test_data_sender(uint32_t to_send)
 	req->data_header.size = to_send;
 	req->data_header.rx_ack_period = 0;
 
-	epacket_dummy_receive(epacket_dummy, &header, payload, sizeof(struct rpc_data_sender_request));
+	epacket_dummy_receive(epacket_dummy, &header, payload,
+			      sizeof(struct rpc_data_sender_request));
 
 	while (receiving) {
 		tx = net_buf_get(tx_fifo, K_MSEC(10));
@@ -262,8 +267,8 @@ ZTEST(rpc_server, test_data_sender)
 	test_data_sender(33333);
 }
 
-static void test_data_receiver(uint32_t total_send, uint8_t skip_after, uint8_t stop_after, uint8_t bad_id_after,
-			       uint8_t ack_period, bool too_much_data)
+static void test_data_receiver(uint32_t total_send, uint8_t skip_after, uint8_t stop_after,
+			       uint8_t bad_id_after, uint8_t ack_period, bool too_much_data)
 {
 	const struct device *epacket_dummy = DEVICE_DT_GET(DT_NODELABEL(epacket_dummy));
 	struct k_fifo *tx_fifo = epacket_dummmy_transmit_fifo_get();
@@ -292,7 +297,8 @@ static void test_data_receiver(uint32_t total_send, uint8_t skip_after, uint8_t 
 	req->header.request_id = request_id;
 	req->data_header.size = send_remaining;
 	req->data_header.rx_ack_period = ack_period;
-	epacket_dummy_receive(epacket_dummy, &header, payload, sizeof(struct rpc_data_receiver_request));
+	epacket_dummy_receive(epacket_dummy, &header, payload,
+			      sizeof(struct rpc_data_receiver_request));
 
 	while (send_remaining > 0) {
 		/* Send randomised data to the server */
@@ -317,7 +323,8 @@ static void test_data_receiver(uint32_t total_send, uint8_t skip_after, uint8_t 
 		} else {
 			packets_sent++;
 			epacket_dummy_receive(epacket_dummy, &header, payload,
-					      sizeof(struct infuse_rpc_data) + (too_much_data ? 64 : to_send));
+					      sizeof(struct infuse_rpc_data) +
+						      (too_much_data ? 64 : to_send));
 		}
 		send_remaining -= to_send;
 		tx_offset += to_send;
@@ -332,7 +339,8 @@ ack_handler:
 				/* clang-format on */
 				struct infuse_rpc_data_ack *data_ack;
 				uint8_t num_offsets =
-					(tx->len - sizeof(*tx_header) - sizeof(*data_ack)) / sizeof(uint32_t);
+					(tx->len - sizeof(*tx_header) - sizeof(*data_ack)) /
+					sizeof(uint32_t);
 
 				tx_header = (void *)tx->data;
 				data_ack = (void *)(tx->data + sizeof(*tx_header));
@@ -340,7 +348,8 @@ ack_handler:
 				zassert_equal(ack_period, num_offsets);
 				packets_acked += num_offsets;
 				for (int i = 1; i < ack_period; i++) {
-					zassert_true(data_ack->offsets[i - 1] < data_ack->offsets[i]);
+					zassert_true(data_ack->offsets[i - 1] <
+						     data_ack->offsets[i]);
 				}
 				net_buf_unref(tx);
 			}

--- a/tests/subsys/tdf/src/main.c
+++ b/tests/subsys/tdf/src/main.c
@@ -42,7 +42,8 @@ static void run_test_case(struct tdf_test_case *tdfs, size_t num_tdfs)
 	/* Add the requested TDFs */
 	for (int i = 0; i < num_tdfs; i++) {
 		t = &tdfs[i];
-		rc = tdf_add(&state, t->p.tdf_id, t->p.tdf_len, t->p.tdf_num, t->p.time, t->p.period, input_buffer);
+		rc = tdf_add(&state, t->p.tdf_id, t->p.tdf_len, t->p.tdf_num, t->p.time,
+			     t->p.period, input_buffer);
 		total_size += t->expected_size;
 		zassert_equal(t->expected_rc, rc);
 		zassert_equal(total_size, state.buf.len);


### PR DESCRIPTION
Reduce the column limit from 120 to 100 to match the zephyr value in order to reduce the reformatting needed when upstreaming.