### PR TITLE
epacket: interfaces: update UDP server again

### DIFF
--- a/subsys/epacket/interfaces/Kconfig
+++ b/subsys/epacket/interfaces/Kconfig
@@ -28,7 +28,7 @@ if EPACKET_INTERFACE_UDP
 
 config EPACKET_INTERFACE_UDP_DEFAULT_URL
 	string "ePacket UDP default server URL"
-	default "ec2-52-62-243-129.ap-southeast-2.compute.amazonaws.com"
+	default "54.66.102.196"
 
 config EPACKET_INTERFACE_UDP_DEFAULT_PORT
 	int "ePacket UDP default server port"


### PR DESCRIPTION
Update the UDP server to a static IP, which should be the last change until DNS is enabled.