### PR TITLE
epacket: udp: use DNS for server

### DIFF
--- a/subsys/epacket/interfaces/Kconfig
+++ b/subsys/epacket/interfaces/Kconfig
@@ -28,7 +28,7 @@ if EPACKET_INTERFACE_UDP
 
 config EPACKET_INTERFACE_UDP_DEFAULT_URL
 	string "ePacket UDP default server URL"
-	default "54.66.102.196"
+	default "udp.dev.infuse-iot.com"
 
 config EPACKET_INTERFACE_UDP_DEFAULT_PORT
 	int "ePacket UDP default server port"


### PR DESCRIPTION
Move to the dev UDP instance using DNS instead of a static IP.