### PR TITLE
[EIS-277] lib: nrf_modem_lib: handle modem errors

### DIFF
--- a/Kconfig.defaults.nrf
+++ b/Kconfig.defaults.nrf
@@ -16,6 +16,8 @@ configdefault NET_IPV6_NBR_CACHE
 	default n if NRF_MODEM_LIB
 configdefault NRF_MODEM_LIB_NET_IF
 	default y
+configdefault NRF_MODEM_LIB_NET_IF_APPLICATION_ERROR_HANDLER
+	default y
 choice NRF_MODEM_LIB_ON_FAULT
 	default NRF_MODEM_LIB_ON_FAULT_APPLICATION_SPECIFIC
 endchoice

--- a/include/infuse/reboot.h
+++ b/include/infuse/reboot.h
@@ -44,6 +44,8 @@ enum infuse_reboot_reason {
 	INFUSE_REBOOT_EXTERNAL_TRIGGER,
 	/* Remote procedure call */
 	INFUSE_REBOOT_RPC,
+	/* Internal LTE modem fault */
+	INFUSE_REBOOT_LTE_MODEM_FAULT,
 	/* Unknown reboot reason */
 	INFUSE_REBOOT_UNKNOWN = 255,
 };

--- a/lib/nrf_modem_lib/nrf_modem_monitor.c
+++ b/lib/nrf_modem_lib/nrf_modem_monitor.c
@@ -14,6 +14,7 @@
 #include <infuse/lib/nrf_modem_monitor.h>
 #include <infuse/fs/kv_store.h>
 #include <infuse/fs/kv_types.h>
+#include <infuse/reboot.h>
 
 #include <modem/nrf_modem_lib.h>
 #include <modem/lte_lc.h>
@@ -197,6 +198,14 @@ static void infuse_modem_info(enum lte_lc_func_mode mode, void *ctx)
 	(void)KV_STORE_WRITE(KV_KEY_LTE_MODEM_IMEI, &modem_imei);
 	/* Modem info has been stored */
 	modem_info_stored = true;
+}
+
+void lte_net_if_modem_fault_handler(struct nrf_modem_fault_info *fault_info)
+{
+	/* Handling any fault properly is uncertain, safest option is to trigger a reboot */
+	LOG_WRN("Modem fault, rebooting in 2 seconds...");
+	infuse_reboot_delayed(INFUSE_REBOOT_LTE_MODEM_FAULT, fault_info->program_counter,
+			      fault_info->reason, K_SECONDS(2));
 }
 
 int nrf_modem_monitor_init(void)

--- a/west.yml
+++ b/west.yml
@@ -23,7 +23,7 @@ manifest:
           - trusted-firmware-m
     - name: sdk-nrf
       path: modules/nrfconnect/sdk-nrf
-      revision: c46564d21f6cc8ec942ff6dac3c4ee79e4c104fb
+      revision: c220f25c9678f8abab809b2a55e96c857e9d9fe2
       import: true
 
   self:


### PR DESCRIPTION
Route LTE modem errors through our reboot infrastructure instead of letting the application try and recover. Properly implementing any recovery is uncertain as there is no way to test implementations.

Rebooting and starting again is the safest option, given how rare modem faults should be in practice.