### PR TITLE
ci: twister: split twister runs

### DIFF
--- a/.github/workflows/twister.yml
+++ b/.github/workflows/twister.yml
@@ -98,8 +98,15 @@ jobs:
           $ZEPHYR_BASE/scripts/twister ${TWISTER_COMMON} ${UNIT_TESTING} -T infuse-sdk
 
       - if: github.event_name == 'schedule'
-        name: Run Tests with Twister (Daily)
+        name: Run Board Tests with Twister (Daily)
         run: |
           export ZEPHYR_BASE=${PWD}/zephyr
-          $ZEPHYR_BASE/scripts/twister ${TWISTER_COMMON} ${VENDOR_FILTER} ${DAILY_OPTIONS} -T infuse-sdk
+          echo 'twister ${TWISTER_COMMON} ${EXTRA_BOARDS} ${DAILY_OPTIONS} -T infuse-sdk'
           $ZEPHYR_BASE/scripts/twister ${TWISTER_COMMON} ${EXTRA_BOARDS} ${DAILY_OPTIONS} -T infuse-sdk
+
+      - if: github.event_name == 'schedule'
+        name: Run Vendor Tests with Twister (Daily)
+        run: |
+          export ZEPHYR_BASE=${PWD}/zephyr
+          echo 'twister ${TWISTER_COMMON} ${VENDOR_FILTER} ${DAILY_OPTIONS} -T infuse-sdk'
+          $ZEPHYR_BASE/scripts/twister ${TWISTER_COMMON} ${VENDOR_FILTER} ${DAILY_OPTIONS} -T infuse-sdk


### PR DESCRIPTION
Split twister runs across two steps to try and resolve weird issue where the second run executes on all platforms.