### PR TITLE
[EIS-287] kv_store: sim_uicc: swap type to string

### DIFF
--- a/include/infuse/fs/kv_types.h
+++ b/include/infuse/fs/kv_types.h
@@ -180,11 +180,17 @@ struct kv_lte_modem_imei {
 
 /* SIM Universal Identifier (https://www.itu.int/en/ITU-T/inr/forms/Pages/iin.aspx) */
 struct kv_lte_sim_uicc {
-	/* Type Code (89 for SIM) */
-	uint8_t industry;
-	/* Remainder of UICC */
-	uint64_t uicc;
+	/* Variable length UICC string */
+	struct kv_string uicc;
 } __packed;
+
+/* clang-format off */
+/* Compile time definition for known array length */
+#define _KV_KEY_LTE_SIM_UICC_VAR(num) \
+	struct { \
+		KV_STRUCT_KV_STRING_VAR(num) uicc; \
+	} __packed
+/* clang-format on */
 
 /* Array of points defining a closed polygon */
 struct kv_geofence {
@@ -271,7 +277,6 @@ enum kv_builtin_size {
 	_KV_KEY_FIXED_LOCATION_SIZE = sizeof(struct kv_fixed_location),
 	_KV_KEY_EPACKET_UDP_PORT_SIZE = sizeof(struct kv_epacket_udp_port),
 	_KV_KEY_LTE_MODEM_IMEI_SIZE = sizeof(struct kv_lte_modem_imei),
-	_KV_KEY_LTE_SIM_UICC_SIZE = sizeof(struct kv_lte_sim_uicc),
 };
 
 /* clang-format off */

--- a/lib/common_boot.c
+++ b/lib/common_boot.c
@@ -72,10 +72,10 @@ static int infuse_common_boot(void)
 	LOG_INF("\t Device: %016llx", device_id);
 	LOG_INF("\t  Board: %s", CONFIG_BOARD);
 #ifdef CONFIG_KV_STORE_LTE_SIM_UICC
-	KV_KEY_TYPE(KV_KEY_LTE_SIM_UICC) sim_uicc;
+	KV_STRUCT_KV_STRING_VAR(24) sim_uicc;
 
-	if (KV_STORE_READ(KV_KEY_LTE_SIM_UICC, &sim_uicc) == sizeof(sim_uicc)) {
-		LOG_INF("\t    SIM: %d%lld", sim_uicc.industry, sim_uicc.uicc);
+	if (KV_STORE_READ(KV_KEY_LTE_SIM_UICC, &sim_uicc) > 0) {
+		LOG_INF("\t    SIM: %s", sim_uicc.value);
 	}
 #endif /* CONFIG_KV_STORE_LTE_SIM_UICC */
 	LOG_INF("\tReboots: %d", reboot.count);

--- a/lib/nrf_modem_lib/nrf_modem_monitor.c
+++ b/lib/nrf_modem_lib/nrf_modem_monitor.c
@@ -37,16 +37,15 @@ static void network_info_update(void)
 	int rc;
 
 	if (!sim_card_queried) {
-		KV_KEY_TYPE(KV_KEY_LTE_SIM_UICC) sim_uicc;
-		uint64_t uicc;
+		KV_STRUCT_KV_STRING_VAR(24) sim_uicc;
 
-		rc = nrf_modem_at_scanf("AT%XICCID", "%%XICCID: 89%" SCNu64, &uicc);
+		rc = nrf_modem_at_scanf("AT%XICCID", "%%XICCID: %24s", &sim_uicc.value);
 		if (rc == 1) {
-			sim_uicc.industry = 89;
-			sim_uicc.uicc = uicc;
-			if (KV_STORE_WRITE(KV_KEY_LTE_SIM_UICC, &sim_uicc) > 0) {
+			sim_uicc.value_num = strlen(sim_uicc.value) + 1;
+			if (kv_store_write(KV_KEY_LTE_SIM_UICC, &sim_uicc, 1 + sim_uicc.value_num) >
+			    0) {
 				/* Print value when first saved to KV store */
-				LOG_INF("SIM: 89%llu", sim_uicc.uicc);
+				LOG_INF("SIM: %s", sim_uicc.value);
 			}
 			sim_card_queried = true;
 		}

--- a/scripts/west_commands/templates/kv_store.json
+++ b/scripts/west_commands/templates/kv_store.json
@@ -136,8 +136,7 @@
             "read_only": true,
             "default": "y if NRF_MODEM_LIB",
             "fields": [
-                {"name": "industry", "type": "uint8_t", "description": "Type Code (89 for SIM)"},
-                {"name": "uicc", "type": "uint64_t", "description": "Remainder of UICC"}
+                {"name": "uicc", "type": "struct kv_string", "description": "Variable length UICC string"}
             ]
         },
         {

--- a/tests/lib/common_boot/src/main.c
+++ b/tests/lib/common_boot/src/main.c
@@ -21,7 +21,7 @@ static void null_dereference(void)
 
 ZTEST(common_boot, test_boot)
 {
-	KV_KEY_TYPE(KV_KEY_LTE_SIM_UICC) sim_uicc = {89, 1000};
+	KV_STRING_CONST(sim_uicc, "89000000000012345");
 	KV_KEY_TYPE(KV_KEY_REBOOTS) reboots;
 	uint64_t time_2020 = civil_time_from_gps(2086, 259218, 0);
 	uint64_t time_2025 = civil_time_from_gps(2347, 259218, 0);


### PR DESCRIPTION
The SIM UICC number is variable length and too large to fit in a single uint64_t. This means `scanf` doesn't work, and parsing in multiple chunks leads to issues when attempting to display. Parse and display as a string to simplify the whole process.