### PR TITLE
[EIS-282] kconfig: defaults: single application image

### DIFF
--- a/Kconfig.defaults.core
+++ b/Kconfig.defaults.core
@@ -82,6 +82,9 @@ choice RNG_GENERATOR_CHOICE
 endchoice
 
 # Trusted-Firmware M
+configdefault TFM_MCUBOOT_IMAGE_NUMBER
+	# A single image reduces upgrade complexity
+	default 1
 configdefault TFM_DEVICETREE_LAYOUT
 	# Only a subset of boards currently support this
 	default y if BOARD_THINGY53_NRF5340_CPUAPP_NS


### PR DESCRIPTION
Present a single application image to MCUboot instead of separate secure and non-secure images. This simplifies the process of managing OTA upgrades.