### PR TITLE
[EIS-299] epacket: add interface address to RX metadata

### DIFF
--- a/include/infuse/epacket/packet.h
+++ b/include/infuse/epacket/packet.h
@@ -18,6 +18,7 @@
 #include <zephyr/device.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/net/buf.h>
+#include <zephyr/bluetooth/bluetooth.h>
 
 #include <infuse/types.h>
 #include <infuse/epacket/interface.h>
@@ -56,6 +57,10 @@ struct epacket_rx_metadata {
 	const struct device *interface;
 	/* Numerical ID for interface */
 	enum epacket_interface_id interface_id;
+	/* Interface specific address */
+	union {
+		bt_addr_le_t bluetooth;
+	} interface_address;
 	/* RSSI of packet (0 = 0dBm, 20 = 20dBm, etc) */
 	int16_t rssi;
 	/* Sequence number of packet */

--- a/subsys/epacket/interfaces/epacket_bt_adv.c
+++ b/subsys/epacket/interfaces/epacket_bt_adv.c
@@ -180,6 +180,7 @@ static void scan_cb(const bt_addr_le_t *addr, int8_t rssi, uint8_t adv_type,
 	meta = net_buf_user_data(rx_buffer);
 	meta->interface = DEVICE_DT_INST_GET(0);
 	meta->interface_id = EPACKET_INTERFACE_BT_ADV;
+	meta->interface_address.bluetooth = *addr;
 	meta->rssi = rssi;
 
 	/* Hand off to ePacket core */


### PR DESCRIPTION
Store the interface address in the RX metadata so we have a record of how to read a device on that interface. Infuse ID != interface address.