### PR TITLE
task_runner: rework compile-time args

### DIFF
--- a/apps/data_logger/src/main.c
+++ b/apps/data_logger/src/main.c
@@ -42,7 +42,7 @@ static const struct task_schedule schedules[] = {
 };
 struct task_schedule_state states[ARRAY_SIZE(schedules)];
 
-TASK_RUNNER_TASKS_DEFINE(app_tasks, app_tasks_data, TDF_LOGGER_TASK, NULL);
+TASK_RUNNER_TASKS_DEFINE(app_tasks, app_tasks_data, (TDF_LOGGER_TASK));
 
 int main(void)
 {

--- a/include/infuse/task_runner/tasks/tdf_logger.h
+++ b/include/infuse/task_runner/tasks/tdf_logger.h
@@ -31,9 +31,9 @@ void task_tdf_logger_fn(struct k_work *work);
  *
  * @param define_mem Define memory (None required)
  * @param define_config Define task
- * @param unused Compile-time argument unused
+ * @param ... Compile-time argument unused
  */
-#define TDF_LOGGER_TASK(define_mem, define_config, unused)                                         \
+#define TDF_LOGGER_TASK(define_mem, define_config, ...)                                            \
 	IF_ENABLED(define_config, ({.name = "tdfl",                                                \
 				    .task_id = TASK_ID_TDF_LOGGER,                                 \
 				    .exec_type = TASK_EXECUTOR_WORKQUEUE,                          \

--- a/west.yml
+++ b/west.yml
@@ -10,7 +10,7 @@ manifest:
 
   projects:
     - name: zephyr
-      revision: 1c74dafa15c4e56825d6ca8571dad596452c7a39
+      revision: 93a7968065cc95d5b853aa7ddc2c3dac8fdf75c8
       # Limit imported repositories to reduce clone time
       import:
         name-allowlist:


### PR DESCRIPTION
Use the existing `FOR_EACH` infrastructure instead of a dedicated pairwise function, which ends up being much more flexibile, supporting an arbitrary number of arguments to the macro.