### PR TITLE
samples: crypto: limit compilation targets

### DIFF
--- a/samples/crypto/ecdh/testcase.yaml
+++ b/samples/crypto/ecdh/testcase.yaml
@@ -1,14 +1,19 @@
 common:
   tags: crypto ecdh
-  build_only: true
   min_flash: 64
   min_ram: 32
 tests:
   crypto.ecdh:
+    platform_allow:
+      - native_sim
+      - qemu_cortex_m3
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - native_sim
       - qemu_cortex_m3
       - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
     harness: console
     harness_config:
       type: one_line

--- a/samples/crypto/profiling/sample.yaml
+++ b/samples/crypto/profiling/sample.yaml
@@ -2,6 +2,12 @@ sample:
   description: Profiling of cryptographic operations
   name: crypto_profiling
 common:
+  platform_allow:
+    - qemu_cortex_m3
+    - native_sim
+    - nrf52840dk_nrf52840
+    - nrf5340dk_nrf5340_cpuapp
+    - nrf5340dk_nrf5340_cpuapp_ns
   integration_platforms:
     - qemu_cortex_m3
     - native_sim


### PR DESCRIPTION
Limit compilation targets in CI to a subset of hardware that we know works.