### PR TITLE
data_logger: exfat: better handling of no SD card

### DIFF
--- a/subsys/data_logger/backends/exfat_multi_file.c
+++ b/subsys/data_logger/backends/exfat_multi_file.c
@@ -282,7 +282,7 @@ int logger_exfat_init(const struct device *dev)
 {
 	const struct dl_exfat_config *config = dev->config;
 	struct dl_exfat_data *data = dev->data;
-	bool infuse_fs = false;
+	bool infuse_fs = true;
 	char disk_path[16];
 	FRESULT res;
 
@@ -295,6 +295,9 @@ int logger_exfat_init(const struct device *dev)
 	LOG_DBG("First mount: %d", res);
 	if (res == FR_OK) {
 		infuse_fs = filesystem_is_infuse(dev);
+	} else if (res == FR_NOT_READY) {
+		LOG_WRN("Disk '%s' not ready", config->disk);
+		return -EIO;
 	}
 	/* Handle standard mount failures */
 	if ((res == FR_NO_FILESYSTEM) || (!infuse_fs)) {

--- a/subsys/data_logger/backends/exfat_single_file.c
+++ b/subsys/data_logger/backends/exfat_single_file.c
@@ -219,7 +219,7 @@ int logger_exfat_init(const struct device *dev)
 {
 	const struct dl_exfat_config *config = dev->config;
 	struct dl_exfat_data *data = dev->data;
-	bool infuse_fs = false;
+	bool infuse_fs = true;
 	char path[40];
 	FRESULT res;
 	FILINFO fno;
@@ -231,6 +231,9 @@ int logger_exfat_init(const struct device *dev)
 	LOG_DBG("First mount: %d", res);
 	if (res == FR_OK) {
 		infuse_fs = filesystem_is_infuse(dev);
+	} else if (res == FR_NOT_READY) {
+		LOG_WRN("Disk '%s' not ready", config->disk);
+		return -EIO;
 	}
 	/* Format container file */
 	snprintf(path, sizeof(path), "%s:infuse_%016llx_000000.bin", config->disk,

--- a/west.yml
+++ b/west.yml
@@ -10,7 +10,7 @@ manifest:
 
   projects:
     - name: zephyr
-      revision: 6ef909c5bcd9b485bedb85234ddda507811556cf
+      revision: 01680e6462384a602d4d40db23d9c99e07c52ddf
       # Limit imported repositories to reduce clone time
       import:
         name-allowlist:


### PR DESCRIPTION
Add explicit handling of the no SD card found case, which prevents attempting to initialise the filesystem a second time.