### PR TITLE
samples: validation: fix compiler warnings

### DIFF
--- a/samples/validation/src/main.c
+++ b/samples/validation/src/main.c
@@ -55,7 +55,9 @@ int main(void)
 			break;
 		}
 	}
-	VALIDATION_REPORT_INFO("SYS", "Complete");
+	(void)validators_failed;
+	VALIDATION_REPORT_INFO("SYS", "Complete with %d/%d passed", (int32_t)validators_passed,
+			       (int32_t)validators_registered);
 	k_sleep(K_FOREVER);
 	return 0;
 }


### PR DESCRIPTION
Fix compiler warnings when compiled for platforms that don't run any tests.