### PR TITLE
[EIS-450] task_runner: tasks: gnss_ubx: minimum required accuracy

### DIFF
--- a/subsys/task_runner/tasks/Kconfig
+++ b/subsys/task_runner/tasks/Kconfig
@@ -66,6 +66,10 @@ config TASK_RUNNER_TASK_GNSS_UBX
 
 if TASK_RUNNER_TASK_GNSS_UBX
 
+config TASK_RUNNER_GNSS_MINIMUM_ACCURACY_M
+	int "Accuracies worse than this threshold are reported as (-181,-91)"
+	default 10000
+
 config TASK_RUNNER_GNSS_TIME_RESYNC_PERIOD_SEC
 	int "Resynchronise time from GNSS every N seconds"
 	default 3600

--- a/subsys/task_runner/tasks/task_gnss_ubx.c
+++ b/subsys/task_runner/tasks/task_gnss_ubx.c
@@ -137,6 +137,12 @@ static void log_and_publish(struct gnss_run_state *state, const struct ubx_msg_n
 		llha.h_acc = INT32_MAX;
 		llha.v_acc = INT32_MAX;
 	}
+	/* Set invalid location on insufficient accuracy */
+	if (pvt->h_acc > (CONFIG_TASK_RUNNER_GNSS_MINIMUM_ACCURACY_M * 1000)) {
+		llha.location.longitude = -1810000000;
+		llha.location.latitude = -910000000;
+		llha.location.height = 0;
+	}
 
 	/* Publish new data reading */
 	zbus_chan_pub(ZBUS_CHAN, &llha, K_FOREVER);


### PR DESCRIPTION
Add a minimum required accuracy before locations from the modem are provided to the system. This is done to prevent locations that are hundreds or thousands of kilometers off from being used for decisions.

Note that the information is still broadcast to inform other libraries that the fix is running.