### PR TITLE
[EIS-448] gnss: gnss_ubx_modem: don't block system workqueue

### DIFF
--- a/drivers/gnss/Kconfig
+++ b/drivers/gnss/Kconfig
@@ -23,6 +23,20 @@ module = U_BLOX_M10_I2C
 module-str = u-blox M10
 source "subsys/logging/Kconfig.template.log_config"
 
+config GNSS_U_BLOX_M10_PIPE_SIZE
+	int "UBX modem pipe size"
+	range 128 2048
+	default 512
+	help
+	  Maximum number of bytes that can be stored in the pipe buffer.
+
+config GNSS_U_BLOX_M10_MAX_MSG_SIZE
+	int "UBX modem pipe size"
+	range 128 512
+	default 256
+	help
+	  Maximum size of a UBX message that driver can handle.
+
 config GNSS_U_BLOX_M10_NO_API_COMPAT
 	bool "Drop compatibility with the Zephyr GNSS API"
 	help

--- a/include/infuse/gnss/ubx/cfg.h
+++ b/include/infuse/gnss/ubx/cfg.h
@@ -520,6 +520,7 @@ static inline void ubx_msg_prepare_valset(struct net_buf_simple *buf, uint8_t la
  *
  * @param buf Buffer to prepare
  * @param layer Layer to query configuration for
+ * @param offset Start value offset for query
  */
 static inline void ubx_msg_prepare_valget(struct net_buf_simple *buf, uint8_t layer, uint8_t offset)
 {

--- a/include/infuse/gnss/ubx/modem.h
+++ b/include/infuse/gnss/ubx/modem.h
@@ -14,6 +14,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/net/buf.h>
 #include <zephyr/modem/pipe.h>
+#include <zephyr/sys/ring_buffer.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -81,7 +82,9 @@ struct ubx_modem_data {
 	/* List of message handlers */
 	sys_slist_t handlers;
 	/* Data buffer to read bytes into */
-	uint8_t rx_buffer[1024];
+	uint8_t rx_buffer[CONFIG_GNSS_U_BLOX_M10_MAX_MSG_SIZE];
+	/* Bytes pending in rx_buffer */
+	uint16_t rx_buffer_pending;
 };
 
 /**

--- a/subsys/modem/backends/Kconfig
+++ b/subsys/modem/backends/Kconfig
@@ -4,4 +4,5 @@ config MODEM_BACKEND_U_BLOX_I2C
 	bool "u-blox I2C modem backend"
 	select MODEM_PIPE
 	select POLL
+	select RING_BUFFER
 	depends on I2C_RTIO

--- a/subsys/modem/backends/modem_backend_u_blox_i2c.c
+++ b/subsys/modem/backends/modem_backend_u_blox_i2c.c
@@ -41,17 +41,58 @@ static void write_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg)
 	modem_pipe_notify_transmit_idle(&backend->pipe);
 }
 
-static void bytes_pending_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg)
+static void fifo_bytes_read_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg)
 {
-	struct rtio_cqe *wr_cqe, *rd_cqe;
 	struct modem_backend_ublox_i2c *backend = arg;
-	bool failed = false;
+	struct rtio_cqe *wr_cqe, *rd_cqe;
+	int rc = 0;
+
+	/* Dump received data */
+	LOG_HEXDUMP_DBG(backend->pipe_ring_buf.buffer + backend->pipe_ring_buf.put_tail,
+			backend->bytes_pending, "RX");
+
+	/* Finish buffer put */
+	ring_buf_put_finish(&backend->pipe_ring_buf, backend->bytes_pending);
 
 	/* Release bus */
 	k_sem_give(&backend->bus_sem);
 
-	/* Can't release directly in the completion callback */
+	/* Consume completion events */
+	wr_cqe = rtio_cqe_consume(r);
+	rd_cqe = rtio_cqe_consume(r);
+
+	__ASSERT_NO_MSG(wr_cqe != NULL);
+	__ASSERT_NO_MSG(rd_cqe != NULL);
+
+	if (wr_cqe->result < 0) {
+		rc = wr_cqe->result;
+	} else if (rd_cqe->result < 0) {
+		rc = rd_cqe->result;
+	}
+	rtio_cqe_release(r, wr_cqe);
+	rtio_cqe_release(r, rd_cqe);
+
+	/* Notify consumers that data exists to read */
+	modem_pipe_notify_receive_ready(&backend->pipe);
+
+	/* Release bus */
 	pm_device_runtime_put_async(backend->i2c->bus, K_MSEC(10));
+
+	/* If in interrupt driven mode and data ready pin still asserted after read, poll again */
+	if (!(backend->flags & MODE_POLLING)) {
+		if (gpio_pin_get_dt(backend->data_ready)) {
+			LOG_DBG("Rescheduling poll");
+			k_work_reschedule(&backend->fifo_read, K_NO_WAIT);
+		}
+	}
+}
+
+static void fifo_bytes_pending_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg)
+{
+	struct modem_backend_ublox_i2c *backend = arg;
+	struct rtio_cqe *wr_cqe, *rd_cqe;
+	bool failed = false;
+	int rc;
 
 	/* Register is in BE format */
 	backend->bytes_pending = sys_be16_to_cpu(backend->bytes_pending);
@@ -79,31 +120,75 @@ static void bytes_pending_cb(struct rtio *r, const struct rtio_sqe *sqe, void *a
 
 	/* If in polling mode, or query failed */
 	if ((backend->flags & MODE_POLLING) || failed) {
-		k_work_reschedule(&backend->pending_bytes_query, backend->poll_period);
+		/* Reschedule another data poll */
+		k_work_reschedule(&backend->fifo_read, backend->poll_period);
 	}
-	if (!failed) {
-		LOG_DBG("Pending: %d bytes", backend->bytes_pending);
-		if (backend->bytes_pending > 0) {
-			modem_pipe_notify_receive_ready(&backend->pipe);
-		}
+	/* If we aren't running the FIFO read */
+	if (failed || (backend->bytes_pending == 0)) {
+		/* Release bus */
+		k_sem_give(&backend->bus_sem);
+		/* Can't release directly in the completion callback */
+		pm_device_runtime_put_async(backend->i2c->bus, K_MSEC(10));
+		return;
+	}
+
+	uint16_t pending = backend->bytes_pending;
+	struct rtio_sqe *wr_sqe, *rd_sqe, *cb_sqe;
+	const uint8_t fifo_addr = 0xFF;
+	uint8_t *output_buf;
+
+	/* Limit read to buffer claim size */
+	backend->bytes_pending =
+		ring_buf_put_claim(&backend->pipe_ring_buf, &output_buf, backend->bytes_pending);
+
+	LOG_DBG("Pending: %d Reading: %d", pending, backend->bytes_pending);
+
+	/* Prepare RTIO sequence */
+	wr_sqe = rtio_sqe_acquire(&i2c_rtio);
+	rd_sqe = rtio_sqe_acquire(&i2c_rtio);
+	cb_sqe = rtio_sqe_acquire(&i2c_rtio);
+
+	__ASSERT_NO_MSG(wr_sqe != NULL);
+	__ASSERT_NO_MSG(rd_sqe != NULL);
+	__ASSERT_NO_MSG(cb_sqe != NULL);
+
+	rtio_sqe_prep_tiny_write(wr_sqe, &i2c_iodev, RTIO_PRIO_NORM, &fifo_addr, 1, NULL);
+	rtio_sqe_prep_read(rd_sqe, &i2c_iodev, 0, output_buf, backend->bytes_pending, NULL);
+	rtio_sqe_prep_callback(cb_sqe, fifo_bytes_read_cb, (void *)backend, NULL);
+
+	wr_sqe->flags |= RTIO_SQE_TRANSACTION;
+	rd_sqe->flags |= RTIO_SQE_CHAINED;
+	cb_sqe->flags |= RTIO_SQE_NO_RESPONSE;
+
+	rd_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+
+	/* Submit work */
+	rc = rtio_submit(&i2c_rtio, 0);
+	if (rc < 0) {
+		LOG_ERR("Failed to submit RTIO (%d)", rc);
+		/* Release bus */
+		k_sem_give(&backend->bus_sem);
+		/* Can't release directly in the completion callback */
+		pm_device_runtime_put_async(backend->i2c->bus, K_MSEC(10));
 	}
 }
 
-static void pending_bytes_poll(struct k_work *work)
+static void fifo_read_start(struct k_work *work)
 {
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct modem_backend_ublox_i2c *backend =
-		CONTAINER_OF(dwork, struct modem_backend_ublox_i2c, pending_bytes_query);
+		CONTAINER_OF(dwork, struct modem_backend_ublox_i2c, fifo_read);
 	struct rtio_sqe *wr_sqe, *rd_sqe, *cb_sqe;
 	const uint8_t len_addr = 0xFD;
 	int rc;
 
 	if (k_sem_take(&backend->bus_sem, K_NO_WAIT) < 0) {
-		/* Bus in use, try again in 1 msec*/
+		/* Bus in use, try again in 1 msec */
 		k_work_reschedule(dwork, K_MSEC(1));
 		return;
 	}
 
+	/* Prepare RTIO sequence */
 	wr_sqe = rtio_sqe_acquire(&i2c_rtio);
 	rd_sqe = rtio_sqe_acquire(&i2c_rtio);
 	cb_sqe = rtio_sqe_acquire(&i2c_rtio);
@@ -114,7 +199,7 @@ static void pending_bytes_poll(struct k_work *work)
 
 	rtio_sqe_prep_tiny_write(wr_sqe, &i2c_iodev, RTIO_PRIO_NORM, &len_addr, 1, NULL);
 	rtio_sqe_prep_read(rd_sqe, &i2c_iodev, 0, (uint8_t *)&backend->bytes_pending, 2, NULL);
-	rtio_sqe_prep_callback(cb_sqe, bytes_pending_cb, (void *)backend, NULL);
+	rtio_sqe_prep_callback(cb_sqe, fifo_bytes_pending_cb, (void *)backend, NULL);
 
 	wr_sqe->flags |= RTIO_SQE_TRANSACTION;
 	rd_sqe->flags |= RTIO_SQE_CHAINED;
@@ -125,6 +210,7 @@ static void pending_bytes_poll(struct k_work *work)
 	/* Power up I2C */
 	pm_device_runtime_get(backend->i2c->bus);
 
+	/* Submit RTIO sequence */
 	rc = rtio_submit(&i2c_rtio, 0);
 	if (rc < 0) {
 		LOG_ERR("Failed to submit RTIO (%d)", rc);
@@ -140,7 +226,7 @@ static int modem_backend_ublox_i2c_open(void *data)
 
 	/* Schedule the boot poll loop */
 	backend->flags = MODE_BOOTING | MODE_POLLING;
-	k_work_reschedule(&backend->pending_bytes_query, K_NO_WAIT);
+	k_work_reschedule(&backend->fifo_read, K_NO_WAIT);
 	return 0;
 }
 
@@ -151,7 +237,7 @@ static int modem_backend_ublox_i2c_close(void *data)
 	LOG_DBG("Closing I2C modem backend");
 
 	/* Cancel any pending queries */
-	k_work_cancel_delayable(&backend->pending_bytes_query);
+	k_work_cancel_delayable(&backend->fifo_read);
 	return 0;
 }
 
@@ -188,101 +274,11 @@ static int modem_backend_ublox_i2c_transmit(void *data, const uint8_t *buf, size
 	return rc == 0 ? size : rc;
 }
 
-static void bytes_read_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg)
-{
-	struct rtio_cqe *wr_cqe, *rd_cqe;
-	struct modem_backend_ublox_i2c *backend = arg;
-	int rc = 0;
-
-	/* Release bus */
-	k_sem_give(&backend->bus_sem);
-
-	/* Consume completion events */
-	wr_cqe = rtio_cqe_consume(r);
-	rd_cqe = rtio_cqe_consume(r);
-
-	__ASSERT_NO_MSG(wr_cqe != NULL);
-	__ASSERT_NO_MSG(rd_cqe != NULL);
-
-	if (wr_cqe->result < 0) {
-		rc = wr_cqe->result;
-	} else if (rd_cqe->result < 0) {
-		rc = rd_cqe->result;
-	}
-	rtio_cqe_release(r, wr_cqe);
-	rtio_cqe_release(r, rd_cqe);
-
-	/* Notify reader of done and status */
-	k_poll_signal_raise(&backend->read_result, rc);
-}
-
 static int modem_backend_ublox_i2c_receive(void *data, uint8_t *buf, size_t size)
 {
 	struct modem_backend_ublox_i2c *backend = data;
-	struct rtio_sqe *wr_sqe, *rd_sqe, *cb_sqe;
-	const uint8_t fifo_addr = 0xFF;
-	uint16_t to_read = MIN(size, backend->bytes_pending);
-	int ignore, rc;
 
-	if (k_sem_take(&backend->bus_sem, K_MSEC(100)) < 0) {
-		return -EAGAIN;
-	}
-
-	wr_sqe = rtio_sqe_acquire(&i2c_rtio);
-	rd_sqe = rtio_sqe_acquire(&i2c_rtio);
-	cb_sqe = rtio_sqe_acquire(&i2c_rtio);
-
-	__ASSERT_NO_MSG(wr_sqe != NULL);
-	__ASSERT_NO_MSG(rd_sqe != NULL);
-	__ASSERT_NO_MSG(cb_sqe != NULL);
-
-	rtio_sqe_prep_tiny_write(wr_sqe, &i2c_iodev, RTIO_PRIO_NORM, &fifo_addr, 1, NULL);
-	rtio_sqe_prep_read(rd_sqe, &i2c_iodev, 0, buf, to_read, NULL);
-	rtio_sqe_prep_callback(cb_sqe, bytes_read_cb, (void *)backend, NULL);
-
-	wr_sqe->flags |= RTIO_SQE_TRANSACTION;
-	rd_sqe->flags |= RTIO_SQE_CHAINED;
-	cb_sqe->flags |= RTIO_SQE_NO_RESPONSE;
-
-	rd_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
-
-	/* Reset poll signal */
-	k_poll_signal_reset(&backend->read_result);
-
-	/* Power up I2C */
-	pm_device_runtime_get(backend->i2c->bus);
-
-	LOG_DBG("Reading %d bytes from FIFO", to_read);
-
-	/* Submit work */
-	rc = rtio_submit(&i2c_rtio, 0);
-	if (rc < 0) {
-		LOG_ERR("Failed to submit RTIO (%d)", rc);
-		return rc;
-	}
-
-	/* Wait for read to complete */
-	struct k_poll_event events[] = {
-		K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY,
-					 &backend->read_result),
-	};
-	k_poll(events, ARRAY_SIZE(events), K_FOREVER);
-	k_poll_signal_check(&backend->read_result, &ignore, &rc);
-	pm_device_runtime_put(backend->i2c->bus);
-
-	/* If in interrupt driven mode and data ready pin still asserted after read, poll again */
-	if (!(backend->flags & MODE_POLLING)) {
-		if (gpio_pin_get_dt(backend->data_ready)) {
-			LOG_DBG("Rescheduling poll");
-			k_work_reschedule(&backend->pending_bytes_query, K_NO_WAIT);
-		}
-	}
-
-	/* Dump received data */
-	LOG_HEXDUMP_DBG(buf, to_read, "RX");
-
-	/* Return number of bytes read on success */
-	return rc == 0 ? to_read : rc;
+	return ring_buf_get(&backend->pipe_ring_buf, buf, size);
 }
 
 static void data_ready_gpio_callback(const struct device *dev, struct gpio_callback *cb,
@@ -293,7 +289,7 @@ static void data_ready_gpio_callback(const struct device *dev, struct gpio_callb
 
 	LOG_DBG("Data ready interrupt");
 	/* Schedule the FIFO data query */
-	k_work_reschedule(&backend->pending_bytes_query, K_NO_WAIT);
+	k_work_reschedule(&backend->fifo_read, K_NO_WAIT);
 }
 
 struct modem_pipe_api modem_backend_ublox_i2c_api = {
@@ -312,9 +308,10 @@ struct modem_pipe *modem_backend_ublox_i2c_init(struct modem_backend_ublox_i2c *
 	i2c_iodev.data = (void *)config->i2c;
 	k_poll_signal_init(&backend->read_result);
 	k_poll_signal_init(&backend->read_result);
-	k_work_init_delayable(&backend->pending_bytes_query, pending_bytes_poll);
+	k_work_init_delayable(&backend->fifo_read, fifo_read_start);
 	k_sem_init(&backend->bus_sem, 1, 1);
 	modem_pipe_init(&backend->pipe, backend, &modem_backend_ublox_i2c_api);
+	ring_buf_init(&backend->pipe_ring_buf, sizeof(backend->pipe_memory), backend->pipe_memory);
 	gpio_init_callback(&backend->data_ready_cb, data_ready_gpio_callback,
 			   BIT(config->data_ready->pin));
 	if (gpio_add_callback(config->data_ready->port, &backend->data_ready_cb) < 0) {
@@ -332,5 +329,5 @@ void modem_backend_ublox_i2c_use_data_ready_gpio(struct modem_backend_ublox_i2c 
 	(void)gpio_pin_configure_dt(backend->data_ready, GPIO_INPUT);
 	(void)gpio_pin_interrupt_configure_dt(backend->data_ready, GPIO_INT_EDGE_TO_ACTIVE);
 	/* Trigger a query immediately in case line already high */
-	k_work_reschedule(&backend->pending_bytes_query, K_NO_WAIT);
+	k_work_reschedule(&backend->fifo_read, K_NO_WAIT);
 }


### PR DESCRIPTION
Don't block the system workqueue by performing the data read in the `.receive` function. Instead perform the read operation asynchronously as a continuation of the pending bytes query, placing the bytes into a FIFO. The receive callback then only needs to pull bytes from the FIFO.