### PR TITLE
manifest: update zephyr fork

### DIFF
--- a/boards/embeint/tauro/tauro_nrf9151_common.dtsi
+++ b/boards/embeint/tauro/tauro_nrf9151_common.dtsi
@@ -51,7 +51,7 @@
 	bq25185: bq25185 {
 		compatible = "current-sense-amplifier";
 		io-channels = <&adc 0>;
-		sense-resistor-micro-ohms = <300000000>;
+		sense-resistor-milli-ohms = <300000>;
 		sense-gain-div = <300>;
 	};
 

--- a/west.yml
+++ b/west.yml
@@ -10,7 +10,7 @@ manifest:
 
   projects:
     - name: zephyr
-      revision: d455d9d0ee421e7f0e64c387fe55682cd39697b5
+      revision: e1a699a55055fd8e6d2204a7d2e22d53cd3efb57
       # Limit imported repositories to reduce clone time
       import:
         name-allowlist:


### PR DESCRIPTION
Update zephyr fork to specify sense resistors in milli-ohms, not micro-ohms.