### PR TITLE
tests: fix `qemu_cortex_m0` compile errors

### DIFF
--- a/tests/subsys/kv_store/boards/qemu_cortex_m0.overlay
+++ b/tests/subsys/kv_store/boards/qemu_cortex_m0.overlay
@@ -1,0 +1,5 @@
+/ {
+	chosen {
+		infuse,kv-partition = &storage_partition;
+	};
+};

--- a/tests/subsys/secure_storage/boards/qemu_cortex_m0.overlay
+++ b/tests/subsys/secure_storage/boards/qemu_cortex_m0.overlay
@@ -1,0 +1,5 @@
+/ {
+	chosen {
+		infuse,kv-partition = &storage_partition;
+	};
+};


### PR DESCRIPTION
Add missing `infuse,kv-partition` choices for applications that run on `qemu_cortex_m0`.