### PR TITLE
reboot: remove `INFUSE_REBOOT_EXFAT_DFU`

### DIFF
--- a/apps/data_logger/src/main.c
+++ b/apps/data_logger/src/main.c
@@ -178,7 +178,7 @@ static void dfu_exfat_run(void)
 			LOG_INF("New image copied");
 			if (boot_request_upgrade_multi(0, 0) == 0) {
 				LOG_INF("Rebooting into new image");
-				infuse_reboot(INFUSE_REBOOT_EXFAT_DFU, 0x00, 0x00);
+				infuse_reboot(INFUSE_REBOOT_DFU, (uintptr_t)dfu_exfat_run, 0x00);
 			}
 		}
 	}

--- a/include/infuse/dfu/exfat.h
+++ b/include/infuse/dfu/exfat.h
@@ -50,7 +50,7 @@ typedef void (*dfu_exfat_progress_cb_t)(size_t copied, size_t total);
  * if (dfu_exfat_app_upgrade_exists(logger, &upgrade_version) == 1) {
  *   if (dfu_exfat_app_upgrade_copy(logger, upgrade_version, upgrade_partition, NULL) == 0) {
  *     if (boot_request_upgrade_multi(0, 0) == 0) {
- *       infuse_reboot(INFUSE_REBOOT_EXFAT_DFU, 0x00, 0x00);
+ *       infuse_reboot(INFUSE_REBOOT_DFU, 0x00, 0x00);
  *     }
  *   }
  * }

--- a/include/infuse/reboot.h
+++ b/include/infuse/reboot.h
@@ -48,14 +48,12 @@ enum infuse_reboot_reason {
 	INFUSE_REBOOT_LTE_MODEM_FAULT = 131,
 	/* MCUmgr request */
 	INFUSE_REBOOT_MCUMGR = 132,
-	/* exFAT DFU triggered */
-	INFUSE_REBOOT_EXFAT_DFU = 133,
+	/* Rebooting due to configuration change */
+	INFUSE_REBOOT_CFG_CHANGE = 133,
 	/* Software watchdog has expired */
 	INFUSE_REBOOT_SW_WATCHDOG = 134,
 	/* Rebooting for device firmware update */
 	INFUSE_REBOOT_DFU = 135,
-	/* Rebooting due to configuration change */
-	INFUSE_REBOOT_CFG_CHANGE = 136,
 	/* Unknown reboot reason */
 	INFUSE_REBOOT_UNKNOWN = 255,
 };


### PR DESCRIPTION
Remove the `INFUSE_REBOOT_EXFAT_DFU` enum value and roll it into
`INFUSE_REBOOT_DFU`. Reuse the enum value for `INFUSE_REBOOT_CFG_CHANGE`
as neither have yet been deployed.