### PR TITLE
subsys: validation_bluetooth: fix message log

### DIFF
--- a/subsys/validation/validation_bluetooth.c
+++ b/subsys/validation/validation_bluetooth.c
@@ -50,10 +50,12 @@ int infuse_validation_bluetooth(uint8_t flags)
 			VALIDATION_REPORT_ERROR(TEST, "Advertising TX timeout");
 			goto test_end;
 		}
+
+		rc = send_rc;
 		if (send_rc == 0) {
 			VALIDATION_REPORT_INFO(TEST, "Advertising TX succeeded");
 		} else {
-			VALIDATION_REPORT_ERROR(TEST, "Advertising TX failed");
+			VALIDATION_REPORT_ERROR(TEST, "Advertising TX failed (%d)", send_rc);
 		}
 	}
 


### PR DESCRIPTION
Fix message logging to prevent an error and success being logged at the same time.
Also improved error logging to include the error code.

example on an unprovisioned board:
```
002162:BT:INFO:START
[00:00:02.166,107] <inf> epacket_keys: Regenerating derived key 02 (bt_adv) for rotation 14605
[00:00:02.166,625] <err> epacket_keys: Key derivation failed (-5)
[00:00:02.166,625] <wrn> epacket_bt_adv: Failed to encrypt
002166:BT:ERROR:Advertising TX failed
002166:BT:PASS:PASSED
```
to
```
002164:BT:INFO:START
[00:00:02.167,907] <inf> epacket_keys: Regenerating derived key 02 (bt_adv) for rotation 14605
[00:00:02.168,273] <err> epacket_keys: Key derivation failed (-5)
[00:00:02.168,273] <wrn> epacket_bt_adv: Failed to encrypt
002168:BT:ERROR:Advertising TX failed (-5)
```
