### PR TITLE
epacket: packet: add interface address to TX metadata

### DIFF
--- a/include/infuse/epacket/packet.h
+++ b/include/infuse/epacket/packet.h
@@ -45,6 +45,12 @@ union epacket_interface_address {
 	bt_addr_le_t bluetooth;
 };
 
+/* Empty interface address */
+#define EPACKET_ADDR_ALL                                                                           \
+	(union epacket_interface_address)                                                          \
+	{                                                                                          \
+	}
+
 /* Metadata for packets that will be transmitted */
 struct epacket_tx_metadata {
 	/* Callback run when TX completes */
@@ -196,9 +202,11 @@ static inline struct net_buf *epacket_alloc_tx_for_interface(const struct device
  * @param auth Authentication level to use for packet
  * @param flags Desired packet flags
  * @param type Packet type
+ * @param dest Destination address
  */
 static inline void epacket_set_tx_metadata(struct net_buf *buf, enum epacket_auth auth,
-					   uint16_t flags, enum infuse_type type)
+					   uint16_t flags, enum infuse_type type,
+					   union epacket_interface_address dest)
 {
 	struct epacket_tx_metadata *meta = net_buf_user_data(buf);
 
@@ -206,6 +214,7 @@ static inline void epacket_set_tx_metadata(struct net_buf *buf, enum epacket_aut
 	meta->flags = flags;
 	meta->type = type;
 	meta->tx_done = NULL;
+	meta->interface_address = dest;
 }
 
 /**

--- a/lib/memfault/infuse_memfault.c
+++ b/lib/memfault/infuse_memfault.c
@@ -247,7 +247,8 @@ bool infuse_memfault_dump_chunks_epacket(const struct device *dev)
 		if ((net_buf_tailroom(tx) < (sizeof(*header) + MEMFAULT_PACKETIZER_MIN_BUF_LEN)) ||
 		    (buf_len == 0)) {
 			/* Set packet metadata and queue for transmission */
-			epacket_set_tx_metadata(tx, EPACKET_AUTH_DEVICE, 0, INFUSE_MEMFAULT_CHUNK);
+			epacket_set_tx_metadata(tx, EPACKET_AUTH_DEVICE, 0, INFUSE_MEMFAULT_CHUNK,
+						EPACKET_ADDR_ALL);
 			epacket_queue(dev, tx);
 
 			/* Need another packet allocated */
@@ -258,7 +259,8 @@ bool infuse_memfault_dump_chunks_epacket(const struct device *dev)
 	/* If there is a pending packet, send it */
 	if (tx) {
 		/* Set packet metadata and queue for transmission */
-		epacket_set_tx_metadata(tx, EPACKET_AUTH_DEVICE, 0, INFUSE_MEMFAULT_CHUNK);
+		epacket_set_tx_metadata(tx, EPACKET_AUTH_DEVICE, 0, INFUSE_MEMFAULT_CHUNK,
+					EPACKET_ADDR_ALL);
 		epacket_queue(dev, tx);
 	}
 

--- a/samples/epacket/udp_bulk_upload/src/main.c
+++ b/samples/epacket/udp_bulk_upload/src/main.c
@@ -66,7 +66,8 @@ int main(void)
 		t_start = k_uptime_get();
 		while (bytes_sent < CONFIG_BULK_UPLOAD_BYTES) {
 			buf = epacket_alloc_tx_for_interface(udp, K_FOREVER);
-			epacket_set_tx_metadata(buf, EPACKET_AUTH_DEVICE, 0x00, 0xFF);
+			epacket_set_tx_metadata(buf, EPACKET_AUTH_DEVICE, 0x00, 0xFF,
+						EPACKET_ADDR_ALL);
 
 			/* Add "payload" and update counters */
 			tailroom = net_buf_tailroom(buf);

--- a/scripts/west_commands/templates/rpc_runner.c.jinja
+++ b/scripts/west_commands/templates/rpc_runner.c.jinja
@@ -85,7 +85,7 @@ void rpc_command_runner(struct net_buf *request)
 	rsp_header->command_id = command_id;
 
 	/* Metadata and core response info */
-	epacket_set_tx_metadata(response, auth, 0x00, INFUSE_RPC_RSP);
+	epacket_set_tx_metadata(response, auth, 0x00, INFUSE_RPC_RSP, EPACKET_ADDR_ALL);
 
 	/* Push response back over incoming interface */
 	epacket_queue(interface, response);

--- a/subsys/data_logger/backends/epacket.c
+++ b/subsys/data_logger/backends/epacket.c
@@ -36,7 +36,7 @@ static int logger_epacket_write(const struct device *dev, uint32_t phy_block,
 		net_buf_unref(buf);
 		return -ENOSPC;
 	}
-	epacket_set_tx_metadata(buf, EPACKET_AUTH_NETWORK, 0x00, data_type);
+	epacket_set_tx_metadata(buf, EPACKET_AUTH_NETWORK, 0x00, data_type, EPACKET_ADDR_ALL);
 	net_buf_add_mem(buf, mem, mem_len);
 	epacket_queue(config->backend, buf);
 	return 0;

--- a/subsys/epacket/epacket.c
+++ b/subsys/epacket/epacket.c
@@ -91,7 +91,8 @@ int epacket_send_key_ids(const struct device *dev, k_timeout_t timeout)
 
 	if (rsp) {
 		/* Infuse ID and network key ID in header, device key ID in payload */
-		epacket_set_tx_metadata(rsp, EPACKET_AUTH_NETWORK, 0, INFUSE_KEY_IDS);
+		epacket_set_tx_metadata(rsp, EPACKET_AUTH_NETWORK, 0, INFUSE_KEY_IDS,
+					EPACKET_ADDR_ALL);
 		net_buf_add_le24(rsp, infuse_security_device_key_identifier());
 		epacket_queue(dev, rsp);
 	}

--- a/subsys/epacket/handlers.c
+++ b/subsys/epacket/handlers.c
@@ -34,7 +34,8 @@ void epacket_default_receive_handler(struct net_buf *buf)
 		if (echo == NULL) {
 			LOG_WRN("Failed to allocate echo response");
 		} else {
-			epacket_set_tx_metadata(echo, meta->auth, 0, INFUSE_ECHO_RSP);
+			epacket_set_tx_metadata(echo, meta->auth, 0, INFUSE_ECHO_RSP,
+						EPACKET_ADDR_ALL);
 			net_buf_add_mem(echo, buf->data, buf->len);
 			epacket_queue(meta->interface, echo);
 		}
@@ -68,7 +69,7 @@ void epacket_gateway_receive_handler(const struct device *backhaul, struct net_b
 		if (epacket_received_packet_append(forward, buf) == 0) {
 			/* Add metadata */
 			epacket_set_tx_metadata(forward, EPACKET_AUTH_DEVICE, 0x00,
-						INFUSE_RECEIVED_EPACKET);
+						INFUSE_RECEIVED_EPACKET, EPACKET_ADDR_ALL);
 			/* Queue for transmission on backhaul */
 			epacket_queue(backhaul, forward);
 		} else {

--- a/subsys/logging/backends/log_backend_epacket_bt.c
+++ b/subsys/logging/backends/log_backend_epacket_bt.c
@@ -53,7 +53,8 @@ static int line_out(uint8_t *data, size_t length, void *output_ctx)
 		return length;
 	}
 
-	epacket_set_tx_metadata(buf, EPACKET_AUTH_DEVICE, 0x00, INFUSE_SERIAL_LOG);
+	epacket_set_tx_metadata(buf, EPACKET_AUTH_DEVICE, 0x00, INFUSE_SERIAL_LOG,
+				EPACKET_ADDR_ALL);
 	net_buf_add_mem(buf, data, MIN(length, net_buf_tailroom(buf)));
 	epacket_queue(dev, buf);
 	return length;

--- a/subsys/rpc/client.c
+++ b/subsys/rpc/client.c
@@ -192,7 +192,8 @@ int rpc_client_command_queue(struct rpc_client_ctx *ctx, enum rpc_builtin_id cmd
 	net_buf_add_mem(cmd_buf, req_params, req_params_len);
 
 	/* Send command */
-	epacket_set_tx_metadata(cmd_buf, EPACKET_AUTH_NETWORK, 0x00, INFUSE_RPC_CMD);
+	epacket_set_tx_metadata(cmd_buf, EPACKET_AUTH_NETWORK, 0x00, INFUSE_RPC_CMD,
+				EPACKET_ADDR_ALL);
 	epacket_queue(ctx->interface, cmd_buf);
 
 	/* Start the timeout timer */
@@ -255,7 +256,8 @@ int rpc_client_data_queue(struct rpc_client_ctx *ctx, uint32_t request_id, uint3
 		net_buf_add_mem(data_buf, bytes, add);
 
 		/* Send data packet */
-		epacket_set_tx_metadata(data_buf, EPACKET_AUTH_NETWORK, 0x00, INFUSE_RPC_DATA);
+		epacket_set_tx_metadata(data_buf, EPACKET_AUTH_NETWORK, 0x00, INFUSE_RPC_DATA,
+					EPACKET_ADDR_ALL);
 		epacket_queue(ctx->interface, data_buf);
 
 		/* Update state */

--- a/subsys/rpc/command_runner.c
+++ b/subsys/rpc/command_runner.c
@@ -223,7 +223,7 @@ void rpc_command_runner(struct net_buf *request)
 	rsp_header->command_id = command_id;
 
 	/* Metadata and core response info */
-	epacket_set_tx_metadata(response, auth, 0x00, INFUSE_RPC_RSP);
+	epacket_set_tx_metadata(response, auth, 0x00, INFUSE_RPC_RSP, EPACKET_ADDR_ALL);
 
 	/* Push response back over incoming interface */
 	epacket_queue(interface, response);

--- a/subsys/rpc/commands/data_sender.c
+++ b/subsys/rpc/commands/data_sender.c
@@ -50,7 +50,7 @@ struct net_buf *rpc_command_data_sender(struct net_buf *request)
 	while (remaining > 0) {
 		/* Allocate the data packet */
 		data_buf = epacket_alloc_tx_for_interface(interface, K_FOREVER);
-		epacket_set_tx_metadata(data_buf, auth, 0x00, INFUSE_RPC_DATA);
+		epacket_set_tx_metadata(data_buf, auth, 0x00, INFUSE_RPC_DATA, EPACKET_ADDR_ALL);
 
 		/* Allocate header and calculate packets on first iteration */
 		data = net_buf_add(data_buf, sizeof(*data));

--- a/subsys/rpc/server.c
+++ b/subsys/rpc/server.c
@@ -118,7 +118,8 @@ static void send_ack(const struct device *interface, uint32_t request_id, uint8_
 	/* Allocate the RPC_DATA_ACK packet */
 	ack = epacket_alloc_tx_for_interface(interface, K_FOREVER);
 	data_ack = net_buf_add(ack, sizeof(*data_ack));
-	epacket_set_tx_metadata(ack, EPACKET_AUTH_NETWORK, 0, INFUSE_RPC_DATA_ACK);
+	epacket_set_tx_metadata(ack, EPACKET_AUTH_NETWORK, 0, INFUSE_RPC_DATA_ACK,
+				EPACKET_ADDR_ALL);
 	/* Populate data */
 	data_ack->request_id = request_id;
 	net_buf_add_mem(ack, data_packet_acks, num_offsets * sizeof(uint32_t));

--- a/subsys/validation/validation_bluetooth.c
+++ b/subsys/validation/validation_bluetooth.c
@@ -41,7 +41,8 @@ int infuse_validation_bluetooth(uint8_t flags)
 
 	if (flags & VALIDATION_BLUETOOTH_ADV_TX) {
 		pkt = epacket_alloc_tx_for_interface(dev, K_FOREVER);
-		epacket_set_tx_metadata(pkt, EPACKET_AUTH_NETWORK, 0, INFUSE_ECHO_REQ);
+		epacket_set_tx_metadata(pkt, EPACKET_AUTH_NETWORK, 0, INFUSE_ECHO_REQ,
+					EPACKET_ADDR_ALL);
 		epacket_set_tx_callback(pkt, tx_done_cb);
 		net_buf_add_mem(pkt, "HELLO", 5);
 		epacket_queue(dev, pkt);

--- a/tests/subsys/epacket/callbacks/src/main.c
+++ b/tests/subsys/epacket/callbacks/src/main.c
@@ -65,7 +65,7 @@ ZTEST(epacket_callbacks, test_interface_tx_failure)
 	/* Allocate buffer */
 	tx = epacket_alloc_tx_for_interface(epacket_dummy, K_NO_WAIT);
 	zassert_not_null(tx);
-	epacket_set_tx_metadata(tx, EPACKET_AUTH_DEVICE, 0x1234, 0x20);
+	epacket_set_tx_metadata(tx, EPACKET_AUTH_DEVICE, 0x1234, 0x20, EPACKET_ADDR_ALL);
 	epacket_set_tx_callback(tx, tx_done);
 	net_buf_add_mem(tx, payload, sizeof(payload));
 
@@ -91,7 +91,7 @@ ZTEST(epacket_callbacks, test_interface_tx_failure)
 	/* Allocate buffer */
 	tx = epacket_alloc_tx_for_interface(epacket_dummy, K_NO_WAIT);
 	zassert_not_null(tx);
-	epacket_set_tx_metadata(tx, EPACKET_AUTH_DEVICE, 0x1234, 0x20);
+	epacket_set_tx_metadata(tx, EPACKET_AUTH_DEVICE, 0x1234, 0x20, EPACKET_ADDR_ALL);
 	epacket_set_tx_callback(tx, tx_done);
 	net_buf_add_mem(tx, payload, sizeof(payload));
 

--- a/tests/subsys/epacket/common/src/main.c
+++ b/tests/subsys/epacket/common/src/main.c
@@ -162,7 +162,7 @@ static struct net_buf *create_received_tdf_packet(uint8_t payload_len, bool encr
 	buf_tx = epacket_alloc_tx(K_NO_WAIT);
 	zassert_not_null(buf_tx);
 	net_buf_reserve(buf_tx, sizeof(struct epacket_bt_adv_frame));
-	epacket_set_tx_metadata(buf_tx, EPACKET_AUTH_DEVICE, 0, INFUSE_TDF);
+	epacket_set_tx_metadata(buf_tx, EPACKET_AUTH_DEVICE, 0, INFUSE_TDF, EPACKET_ADDR_ALL);
 	p = net_buf_add(buf_tx, 60);
 	sys_rand_get(p, 60);
 

--- a/tests/subsys/epacket/handlers/src/main.c
+++ b/tests/subsys/epacket/handlers/src/main.c
@@ -223,7 +223,7 @@ static struct net_buf *create_received_tdf_packet(uint8_t payload_len, bool encr
 	buf_tx = epacket_alloc_tx(K_NO_WAIT);
 	zassert_not_null(buf_tx);
 	net_buf_reserve(buf_tx, sizeof(struct epacket_bt_adv_frame));
-	epacket_set_tx_metadata(buf_tx, EPACKET_AUTH_DEVICE, 0, INFUSE_TDF);
+	epacket_set_tx_metadata(buf_tx, EPACKET_AUTH_DEVICE, 0, INFUSE_TDF, EPACKET_ADDR_ALL);
 	p = net_buf_add(buf_tx, 60);
 	sys_rand_get(p, 60);
 

--- a/tests/subsys/epacket/interfaces/bluetooth_adv/src/main.c
+++ b/tests/subsys/epacket/interfaces/bluetooth_adv/src/main.c
@@ -45,7 +45,7 @@ ZTEST(epacket_bt_adv, test_metadata)
 		tx = epacket_alloc_tx(K_NO_WAIT);
 		zassert_not_null(tx);
 		net_buf_reserve(tx, sizeof(struct epacket_bt_adv_frame));
-		epacket_set_tx_metadata(tx, iter_auth, i, 0x10 + i);
+		epacket_set_tx_metadata(tx, iter_auth, i, 0x10 + i, EPACKET_ADDR_ALL);
 		p = net_buf_add(tx, 60);
 		sys_rand_get(p, 60);
 
@@ -113,7 +113,7 @@ static void test_encrypt_decrypt_auth(enum epacket_auth auth)
 	orig_buf = epacket_alloc_tx(K_NO_WAIT);
 	zassert_not_null(orig_buf);
 	net_buf_reserve(orig_buf, sizeof(struct epacket_bt_adv_frame));
-	epacket_set_tx_metadata(orig_buf, auth, 0, 0x10);
+	epacket_set_tx_metadata(orig_buf, auth, 0, 0x10, EPACKET_ADDR_ALL);
 	p = net_buf_add(orig_buf, 60);
 	sys_rand_get(p, 60);
 

--- a/tests/subsys/epacket/interfaces/dummy/src/main.c
+++ b/tests/subsys/epacket/interfaces/dummy/src/main.c
@@ -44,7 +44,7 @@ ZTEST(epacket_dummy, test_send_queue)
 	/* Allocate buffer */
 	tx = epacket_alloc_tx_for_interface(epacket_dummy, K_NO_WAIT);
 	zassert_not_null(tx);
-	epacket_set_tx_metadata(tx, EPACKET_AUTH_DEVICE, 0x1234, 0x20);
+	epacket_set_tx_metadata(tx, EPACKET_AUTH_DEVICE, 0x1234, 0x20, EPACKET_ADDR_ALL);
 	net_buf_add_mem(tx, payload, sizeof(payload));
 
 	/* Send buffer on interface */

--- a/tests/subsys/epacket/interfaces/serial/src/main.c
+++ b/tests/subsys/epacket/interfaces/serial/src/main.c
@@ -234,7 +234,7 @@ ZTEST(epacket_serial, test_sequence)
 		tx = epacket_alloc_tx(K_NO_WAIT);
 		zassert_not_null(tx);
 		net_buf_reserve(tx, sizeof(struct epacket_serial_frame));
-		epacket_set_tx_metadata(tx, iter_auth, i, 0x10 + i);
+		epacket_set_tx_metadata(tx, iter_auth, i, 0x10 + i, EPACKET_ADDR_ALL);
 		p = net_buf_add(tx, 60);
 		sys_rand_get(p, 60);
 
@@ -285,7 +285,7 @@ ZTEST(epacket_serial, test_encrypt_decrypt)
 	orig_buf = epacket_alloc_tx(K_NO_WAIT);
 	zassert_not_null(orig_buf);
 	net_buf_reserve(orig_buf, sizeof(struct epacket_serial_frame));
-	epacket_set_tx_metadata(orig_buf, EPACKET_AUTH_DEVICE, 0, 0x10);
+	epacket_set_tx_metadata(orig_buf, EPACKET_AUTH_DEVICE, 0, 0x10, EPACKET_ADDR_ALL);
 	p = net_buf_add(orig_buf, 60);
 	sys_rand_get(p, 60);
 

--- a/tests/subsys/epacket/interfaces/udp/src/main.c
+++ b/tests/subsys/epacket/interfaces/udp/src/main.c
@@ -43,7 +43,7 @@ ZTEST(epacket_udp, test_metadata)
 		tx = epacket_alloc_tx(K_NO_WAIT);
 		zassert_not_null(tx);
 		net_buf_reserve(tx, sizeof(struct epacket_udp_frame));
-		epacket_set_tx_metadata(tx, iter_auth, i, 0x10 + i);
+		epacket_set_tx_metadata(tx, iter_auth, i, 0x10 + i, EPACKET_ADDR_ALL);
 		p = net_buf_add(tx, 60);
 		sys_rand_get(p, 60);
 
@@ -114,7 +114,7 @@ static void test_encrypt_decrypt_auth(enum epacket_auth auth)
 	orig_buf = epacket_alloc_tx(K_NO_WAIT);
 	zassert_not_null(orig_buf);
 	net_buf_reserve(orig_buf, sizeof(struct epacket_udp_frame));
-	epacket_set_tx_metadata(orig_buf, auth, 0, 0x10);
+	epacket_set_tx_metadata(orig_buf, auth, 0, 0x10, EPACKET_ADDR_ALL);
 	p = net_buf_add(orig_buf, 60);
 	sys_rand_get(p, 60);
 


### PR DESCRIPTION
Add an interface address to the TX metadata struct to enable backends to recover the destination context if required.