### PR TITLE
tdf: support longer time periods

### DIFF
--- a/include/infuse/data_logger/high_level/tdf.h
+++ b/include/infuse/data_logger/high_level/tdf.h
@@ -66,7 +66,7 @@ enum {
  * @retval -errno Error code from @a tdf_add or @a tdf_data_logger_flush on error
  */
 int tdf_data_logger_log_array_dev(const struct device *dev, uint16_t tdf_id, uint8_t tdf_len,
-				  uint8_t tdf_num, uint64_t time, uint16_t period,
+				  uint8_t tdf_num, uint64_t time, uint32_t period,
 				  const void *data);
 
 /**
@@ -81,7 +81,7 @@ int tdf_data_logger_log_array_dev(const struct device *dev, uint16_t tdf_id, uin
  * @param data TDF data array
  */
 void tdf_data_logger_log_array(uint8_t logger_mask, uint16_t tdf_id, uint8_t tdf_len,
-			       uint8_t tdf_num, uint64_t time, uint16_t period, const void *data);
+			       uint8_t tdf_num, uint64_t time, uint32_t period, const void *data);
 
 /**
  * @brief Add a single TDF to a data logger

--- a/include/infuse/task_runner/task.h
+++ b/include/infuse/task_runner/task.h
@@ -283,7 +283,7 @@ static inline bool task_schedule_tdf_requested(const struct task_schedule *sched
  */
 static inline void task_schedule_tdf_log_array(const struct task_schedule *schedule,
 					       uint8_t tdf_mask, uint16_t tdf_id, uint8_t tdf_len,
-					       uint8_t tdf_num, uint64_t time, uint16_t period,
+					       uint8_t tdf_num, uint64_t time, uint32_t period,
 					       const void *data)
 {
 	if (schedule->task_logging[0].tdf_mask & tdf_mask) {

--- a/include/infuse/tdf/tdf.h
+++ b/include/infuse/tdf/tdf.h
@@ -46,7 +46,7 @@ struct tdf_parsed {
 	/* Number of TDFs */
 	uint8_t tdf_num;
 	/* Time period between TDFs */
-	uint16_t period;
+	uint32_t period;
 	/* TDF data */
 	void *data;
 };
@@ -92,7 +92,7 @@ static inline void tdf_buffer_state_reset(struct tdf_buffer_state *state)
  * @return -ENOMEM Insufficient space to add any TDFs to buffer
  */
 int tdf_add(struct tdf_buffer_state *state, uint16_t tdf_id, uint8_t tdf_len, uint8_t tdf_num,
-	    uint64_t time, uint16_t period, const void *data);
+	    uint64_t time, uint32_t period, const void *data);
 
 /**
  * @brief Initialise TDF parsing state

--- a/subsys/data_logger/high_level/tdf_data_logger.c
+++ b/subsys/data_logger/high_level/tdf_data_logger.c
@@ -220,7 +220,7 @@ int tdf_data_logger_remote_id_set(const struct device *dev, uint64_t remote_id)
 #endif /* TDF_REMOTE_SUPPORT */
 
 static int log_locked(const struct device *dev, uint16_t tdf_id, uint8_t tdf_len, uint8_t tdf_num,
-		      uint64_t time, uint16_t period, const void *mem)
+		      uint64_t time, uint32_t period, const void *mem)
 {
 	struct tdf_logger_data *data = dev->data;
 	int rc;
@@ -257,7 +257,7 @@ relog:
 }
 
 int tdf_data_logger_log_array_dev(const struct device *dev, uint16_t tdf_id, uint8_t tdf_len,
-				  uint8_t tdf_num, uint64_t time, uint16_t period, const void *mem)
+				  uint8_t tdf_num, uint64_t time, uint32_t period, const void *mem)
 {
 	const struct tdf_logger_config *config = dev->config;
 	struct tdf_logger_data *data = dev->data;
@@ -287,7 +287,7 @@ int tdf_data_logger_log_array_dev(const struct device *dev, uint16_t tdf_id, uin
 }
 
 void tdf_data_logger_log_array(uint8_t logger_mask, uint16_t tdf_id, uint8_t tdf_len,
-			       uint8_t tdf_num, uint64_t time, uint16_t period, const void *data)
+			       uint8_t tdf_num, uint64_t time, uint32_t period, const void *data)
 {
 	const struct device *dev;
 

--- a/tests/subsys/tdf/src/main.c
+++ b/tests/subsys/tdf/src/main.c
@@ -413,6 +413,49 @@ ZTEST(tdf, test_add_multiple)
 	run_test_case(tests, ARRAY_SIZE(tests));
 }
 
+ZTEST(tdf, test_add_multiple_long_period)
+{
+	/* Multiple TDFs */
+	struct tdf_test_case tests[] = {
+		{
+			.p =
+				{
+					.time = 0,
+					.tdf_id = 100,
+					.tdf_num = 2,
+					.tdf_len = 4,
+					.period = 131072,
+				},
+			.expected_size = 14,
+			.expected_rc = 2,
+		},
+		{
+			.p =
+				{
+					.time = 0,
+					.tdf_id = 100,
+					.tdf_num = 2,
+					.tdf_len = 4,
+					.period = 131072,
+				},
+			.expected_size = 14,
+			.expected_rc = 2,
+		},
+		{
+			.p =
+				{
+					.time = 0,
+					.tdf_id = 104,
+					.tdf_num = 1,
+					.tdf_len = 4,
+				},
+			.expected_size = 0,
+			.expected_rc = -ENOMEM,
+		},
+	};
+	run_test_case(tests, ARRAY_SIZE(tests));
+}
+
 ZTEST(tdf, test_multiple_too_many)
 {
 	/* More TDFs than fit on the buffer */
@@ -555,6 +598,7 @@ ZTEST(tdf, test_invalid_params)
 	zassert_equal(-EINVAL, tdf_add(&state, UINT16_MAX, 10, 1, 0, 0, input_buffer));
 	zassert_equal(-EINVAL, tdf_add(&state, 100, 0, 1, 0, 0, input_buffer));
 	zassert_equal(-EINVAL, tdf_add(&state, 100, 10, 0, 0, 0, input_buffer));
+	zassert_equal(-EINVAL, tdf_add(&state, 100, 10, 2, 0, UINT32_MAX, input_buffer));
 }
 
 ZTEST(tdf, test_invalid_sizes)


### PR DESCRIPTION
Support time periods of up to 68 minutes in the time array by reserving the top bit of the period as a scale factor. The reduces the maximum value that can be represented at full resolution from 0.999 seconds to 0.499 seconds, but increases the maximum representable period from 0.999 seconds to 68 minutes. The resolution at the higher time scale is 125 ms.