### PR TITLE
[EIS-407] data_logger: backends: optional search hint for init

### DIFF
--- a/subsys/data_logger/backends/common.h
+++ b/subsys/data_logger/backends/common.h
@@ -125,6 +125,22 @@ struct data_logger_api {
 	 * @retval -errno otherwise
 	 */
 	int (*erase)(const struct device *dev, uint32_t phy_block, uint32_t num);
+
+	/**
+	 * @brief Search range hint for initialisation
+	 *
+	 * Optional method to inform upper layer about the block range at which the
+	 * last block can be found. This can be used to optimize the search process
+	 * for loggers with high overheads on arbitrary reads.
+	 *
+	 * @param dev Logger device
+	 * @param hint_start First block that might be the last block with valid data
+	 * @param hint_end Last block that might be the last block with valid data
+	 *
+	 * @retval 0 on success
+	 * @retval -errno otherwise
+	 */
+	int (*search_hint)(const struct device *dev, uint32_t *hint_start, uint32_t *hint_end);
 };
 
 /**

--- a/subsys/data_logger/data_logger.c
+++ b/subsys/data_logger/data_logger.c
@@ -316,11 +316,19 @@ static int current_block_search(const struct device *dev, uint8_t counter)
 	struct data_logger_common_data *data = dev->data;
 	const struct data_logger_api *api = dev->api;
 	struct data_logger_persistent_block_header temp;
-	uint32_t high = data->physical_blocks - 1;
-	uint32_t low = 0;
-	uint32_t mid, res = 0;
+	uint32_t high, low, mid, res = 0;
 	uint32_t max_search;
-	int rc;
+	int rc = -ENOSYS;
+
+	if (api->search_hint) {
+		/* Ask driver for search range hints */
+		rc = api->search_hint(dev, &low, &high);
+	}
+	if (rc < 0) {
+		/* Search hint not supported or failed */
+		high = data->physical_blocks - 1;
+		low = 0;
+	}
 
 	/* Binary search for last block where block_wrap == counter */
 	while (low <= high) {


### PR DESCRIPTION
Enable backend drivers to optionally provide a hint to the upper layers about the block range at which the last valid block can be found. Due to the cost of opening random files on an external SD card, this implementation reduces the search time of a card with 5GB of data from 6 seconds to 1.6 seconds.