### PR TITLE
rpc: kv_reflect_crcs: fix CRC type

### DIFF
--- a/include/infuse/rpc/types.h
+++ b/include/infuse/rpc/types.h
@@ -108,7 +108,7 @@ struct rpc_struct_kv_store_value {
 /** KV store data CRC */
 struct rpc_struct_kv_store_crc {
 	uint16_t id;
-	int32_t crc;
+	uint32_t crc;
 } __packed;
 
 /** Bluetooth LE address */

--- a/scripts/west_commands/templates/kv_definitions.py.jinja
+++ b/scripts/west_commands/templates/kv_definitions.py.jinja
@@ -7,6 +7,7 @@ import ctypes
 
 from infuse_iot.util.ctypes import VLACompatLittleEndianStruct
 
+
 class structs:
 {% for name, info in structs.items() %}
     class {{ name }}(VLACompatLittleEndianStruct):

--- a/scripts/west_commands/templates/rpc.json
+++ b/scripts/west_commands/templates/rpc.json
@@ -21,7 +21,7 @@
             "description": "KV store data CRC",
             "fields": [
                 {"name": "id", "type": "uint16_t"},
-                {"name": "crc", "type": "int32_t"}
+                {"name": "crc", "type": "uint32_t"}
             ]
         },
         "rpc_struct_bt_addr_le": {


### PR DESCRIPTION
Update the type of the CRC32 from `int32_t` to `uint32_t`.