### PR TITLE
kconfig: conditional subsystem enabling

### DIFF
--- a/Kconfig.defaults.core
+++ b/Kconfig.defaults.core
@@ -129,7 +129,7 @@ configdefault WDT_DISABLE_AT_BOOT
 
 # Power Management
 configdefault POWER_DOMAIN
-	default y
+	default y if "$(dt_has_compat,power-domain-gpio)"
 
 # Random numbers
 configdefault ENTROPY_GENERATOR

--- a/Kconfig.defaults.sensor
+++ b/Kconfig.defaults.sensor
@@ -3,11 +3,11 @@
 configdefault SENSOR
 	default y
 configdefault INFUSE_IMU
-	default y
+	default y if "$(dt_alias_enabled,imu0)"
 configdefault GNSS
-	default y
+	default y if "$(dt_alias_enabled,gnss)"
 configdefault FUEL_GAUGE
-	default y
+	default y if "$(dt_alias_enabled,fuel-gauge0)"
 
 # We want to use UBX messages directly
 configdefault GNSS_U_BLOX_NO_API_COMPAT

--- a/boards/embeint/tauro/tauro_nrf9151_defconfig
+++ b/boards/embeint/tauro/tauro_nrf9151_defconfig
@@ -9,9 +9,6 @@ CONFIG_HW_STACK_PROTECTION=y
 # Enable GPIO
 CONFIG_GPIO=y
 
-# Enable power supplies
-CONFIG_POWER_DOMAIN=y
-
 # Enable UART driver
 CONFIG_SERIAL=y
 

--- a/boards/embeint/tauro/tauro_nrf9151_ns_defconfig
+++ b/boards/embeint/tauro/tauro_nrf9151_ns_defconfig
@@ -15,9 +15,6 @@ CONFIG_TRUSTED_EXECUTION_NONSECURE=y
 # Enable GPIO
 CONFIG_GPIO=y
 
-# Enable power supplies
-CONFIG_POWER_DOMAIN=y
-
 # Enable UART driver
 CONFIG_SERIAL=y
 

--- a/tests/subsys/algorithm/algorithms/stationary_windowed/app.overlay
+++ b/tests/subsys/algorithm/algorithms/stationary_windowed/app.overlay
@@ -1,4 +1,8 @@
 / {
+	aliases {
+		imu0 = &imu_emul;
+	};
+
 	imu_emul: imu_emul {
 		compatible = "embeint,imu-emul";
 	};

--- a/tests/subsys/task_runner/tasks/gnss_ubx_m8/app.overlay
+++ b/tests/subsys/task_runner/tasks/gnss_ubx_m8/app.overlay
@@ -1,4 +1,8 @@
 / {
+	aliases {
+		gnss = &gnss_m8_emul;
+	};
+
 	gnss_m8_emul: gnss_m8_emul {
 		compatible = "u-blox,m8-emul";
 		zephyr,pm-device-runtime-auto;

--- a/tests/subsys/task_runner/tasks/imu/app.overlay
+++ b/tests/subsys/task_runner/tasks/imu/app.overlay
@@ -1,4 +1,8 @@
 / {
+	aliases {
+		imu0 = &imu_emul;
+	};
+
 	imu_emul: imu_emul {
 		compatible = "embeint,imu-emul";
 	};


### PR DESCRIPTION
Only enable subsystems by default if an appropriate alias exists. This gets rid of build warnings on platforms without supported hardware.