### PR TITLE
algorithm_runner: requires algorithms to release channel

### DIFF
--- a/include/infuse/algorithm_runner/runner.h
+++ b/include/infuse/algorithm_runner/runner.h
@@ -42,6 +42,19 @@ struct algorithm_runner_common_config {
 	} logging;
 } __packed;
 
+/**
+ * @brief Algorithm implementation
+ *
+ * @warning The algorithm implementation ***MUST*** release the channel reference via @a
+ * zbus_chan_finish before exiting. This should be done as soon as processing of the channel data
+ * has completed.
+ *
+ * @param chan Channel pointer corresponding to @a zbus_channel in
+ * @ref algorithm_runner_common_config. Value is NULL on the very first call to initialise data
+ * structures.
+ * @param config Pointer to the constant algorithm configuration
+ * @param data Pointer to the mutable algorithm state
+ */
 typedef void (*algorithm_run_fn)(const struct zbus_channel *chan, const void *config, void *data);
 
 struct algorithm_runner_algorithm {

--- a/subsys/algorithm_runner/runner.c
+++ b/subsys/algorithm_runner/runner.c
@@ -59,7 +59,6 @@ static void exec_fn(struct k_work *work)
 		/* Run algorithm with the channel claimed */
 		zbus_chan_claim(alg->_changed, K_FOREVER);
 		alg->impl(alg->_changed, alg->config, alg->runtime_state);
-		zbus_chan_finish(alg->_changed);
 		/* Clear new data flag */
 		alg->_changed = NULL;
 	}

--- a/tests/subsys/algorithm/runner/src/main.c
+++ b/tests/subsys/algorithm/runner/src/main.c
@@ -57,6 +57,9 @@ static void algorithm_impl(const struct zbus_channel *chan, const void *config, 
 	zassert_not_null(config);
 	zassert_not_null(data);
 	zassert_equal(d->expected_chan, chan);
+	if (chan) {
+		zbus_chan_finish(chan);
+	}
 	d->run_cnt += 1;
 }
 


### PR DESCRIPTION
Move the responsibility for releasing the zbus channel into the algorithm implementation. This allows the algorithm to release the channel as soon as it has finished processing the data, leaving the channel available while any logging or post-processing takes place.