### PR TITLE
reboot: ignore errors from `retention_clear`

### DIFF
--- a/include/infuse/reboot.h
+++ b/include/infuse/reboot.h
@@ -117,12 +117,16 @@ void infuse_reboot_delayed(enum infuse_reboot_reason reason, uint32_t info1, uin
 /**
  * @brief Query the reason for the previous reboot
  *
+ * If this function returns 0, state->hardware_reason contains the reboot
+ * reason and the hardware register values are cleared.
+ *
  * @warning Will only return valid state on the first call.
  *
  * @param state State storage area
  *
  * @retval 0 On successful state query
  * @retval -ENOENT No stored state exists
+ * @retval -errno Other error from @a retention_read
  */
 int infuse_reboot_state_query(struct infuse_reboot_state *state);
 

--- a/lib/reboot.c
+++ b/lib/reboot.c
@@ -172,6 +172,9 @@ int infuse_reboot_state_query(struct infuse_reboot_state *state)
 	state->hardware_reason = hardware_cause;
 	(void)hwinfo_clear_reset_cause();
 
-	/* Clear the state */
-	return retention_clear(retention);
+	/* Clear the state.
+	 * Ignore errors since hardware registers have already been cleared at this point.
+	 */
+	(void)retention_clear(retention);
+	return 0;
 }


### PR DESCRIPTION
Ignore errors from `retention_clear` since they are not relevant to the overall success of the function. By that point the reboot reason has already been read and the hardware registered cleared.