### PR TITLE
net: dns: skip DNS lookup if AT commands are not safe

### DIFF
--- a/subsys/net/dns/infuse_dns.c
+++ b/subsys/net/dns/infuse_dns.c
@@ -9,6 +9,8 @@
 #include <zephyr/net/socket.h>
 #include <zephyr/logging/log.h>
 
+#include <infuse/lib/nrf_modem_monitor.h>
+
 #include <infuse/net/dns.h>
 
 LOG_MODULE_REGISTER(infuse_dns, LOG_LEVEL_INF);
@@ -26,6 +28,13 @@ int infuse_sync_dns(const char *host, uint16_t port, int family, int socktype,
 	};
 	struct zsock_addrinfo *res = NULL;
 	int rc;
+
+#ifdef CONFIG_INFUSE_NRF_MODEM_MONITOR
+	if (!nrf_modem_monitor_is_at_safe()) {
+		/* Modem may be in a temporarily unresponsive state */
+		return -EAGAIN;
+	}
+#endif /* CONFIG_INFUSE_NRF_MODEM_MONITOR */
 
 #ifdef CONFIG_DNS_RESOLVER
 	/* Take a context */


### PR DESCRIPTION
Return an error if the nRF modem is in a state that is unable to safely handle AT commands. This also affects functions like `nrf_getaddrinfo`.