### PR TITLE
memfault: re-add missing dependency

### DIFF
--- a/lib/memfault/Kconfig
+++ b/lib/memfault/Kconfig
@@ -28,7 +28,7 @@ config MEMFAULT_INFUSE_SECURE_FAULT_KNOWLEDGE
 	  provide the fault information to Memfault if the reboot was
 	  caused by a secure fault.
 
-if MEMFAULT_INFUSE_CONFIG
+if MEMFAULT_INFUSE_CONFIG && MEMFAULT_METRICS
 
 config MEMFAULT_INFUSE_METRICS_BATTERY
 	bool "Battery metrics from Infuse-IoT zbus channel"
@@ -83,6 +83,6 @@ config MEMFAULT_INFUSE_METRICS_SYNC_SUCCESS_EPACKET_UDP
 
 endchoice # MEMFAULT_INFUSE_METRICS_SYNC_SUCCESS
 
-endif # MEMFAULT_INFUSE_CONFIG
+endif # MEMFAULT_INFUSE_CONFIG && MEMFAULT_METRICS
 
 endif # INFUSE_MEMFAULT


### PR DESCRIPTION
The original dependency of `MEMFAULT_INFUSE_CONFIG` on `MEMFAULT_METRICS` was weakened with
`MEMFAULT_INFUSE_SECURE_FAULT_KNOWLEDGE`. Re-add it for the Infuse metrics symbols.