### PR TITLE
kconfig: core: enable `PM` by default

### DIFF
--- a/kconfig/Kconfig.defaults.core
+++ b/kconfig/Kconfig.defaults.core
@@ -25,6 +25,8 @@ configdefault RETAINED_MEM_MUTEX_FORCE_DISABLE
 	default y
 
 # Power management
+configdefault PM
+	default y
 configdefault PM_DEVICE
 	default y
 configdefault PM_DEVICE_RUNTIME


### PR DESCRIPTION
Enable `PM` by default. This only ends up enabled if the SoC family supports it (like STM32) and is required for low power operation.