### PR TITLE
bluetooth: legacy_adv: configurable interval

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -26,3 +26,25 @@ config BT_CONN_AUTO_RSSI_INTERVAL_MS
 	default 1000
 
 endif # BT_CONN_AUTO_RSSI
+
+if BT_HCI_HOST
+
+config BT_INFUSE_LEGACY_ADV_INTERVAL_MIN
+	int "Minimum interval for the Infuse-IoT legacy advertising set"
+	range 30 10000
+	default 1000
+	help
+	  Minimum advertising interval for the legacy Bluetooth advertising set
+	  started by bluetooth_legacy_advertising_run. Valid range is from 30 ms
+	  to 10'000 ms
+
+config BT_INFUSE_LEGACY_ADV_INTERVAL_MAX
+	int "Maximum interval for the Infuse-IoT legacy advertising set"
+	range 60 10240
+	default 1200
+	help
+	  Maximum advertising interval for the legacy Bluetooth advertising set
+	  started by bluetooth_legacy_advertising_run. Valid range is from 10 ms
+	  to 10'240 ms
+
+endif # BT_HCI_HOST

--- a/subsys/bluetooth/legacy_adv.c
+++ b/subsys/bluetooth/legacy_adv.c
@@ -13,12 +13,17 @@
 
 #include <infuse/bluetooth/legacy_adv.h>
 
+BUILD_ASSERT(CONFIG_BT_INFUSE_LEGACY_ADV_INTERVAL_MIN < CONFIG_BT_INFUSE_LEGACY_ADV_INTERVAL_MAX);
+
+/* Bluetooth stack intervals are in 0.625 ms units */
+#define INTERVAL_MIN (CONFIG_BT_INFUSE_LEGACY_ADV_INTERVAL_MIN / 0.625f)
+#define INTERVAL_MAX (CONFIG_BT_INFUSE_LEGACY_ADV_INTERVAL_MAX / 0.625f)
+
 static void legacy_connected(struct bt_le_ext_adv *adv, struct bt_le_ext_adv_connected_info *info);
 static void legacy_recycled(const void *conn);
 
 #define BT_LE_ADV_CONN_SLOW                                                                        \
-	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE, BT_GAP_ADV_SLOW_INT_MIN,                        \
-			BT_GAP_ADV_SLOW_INT_MAX, NULL)
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE, INTERVAL_MIN, INTERVAL_MAX, NULL)
 
 static const struct bt_data ad[] = {
 	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),


### PR DESCRIPTION
Make the advertising interval for the legacy set enabled by `bluetooth_legacy_advertising_run` configurable through Kconfig.