### PR TITLE
validation: disk/flash: include `<string.h>`

### DIFF
--- a/subsys/validation/validation_disk.c
+++ b/subsys/validation/validation_disk.c
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: LicenseRef-Embeint
  */
 
+#include <string.h>
+
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/random/random.h>

--- a/subsys/validation/validation_flash.c
+++ b/subsys/validation/validation_flash.c
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: LicenseRef-Embeint
  */
 
+#include <string.h>
+
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/random/random.h>


### PR DESCRIPTION
Explicitly include `<string.h>` to get `memcmp` instead of relying on one of the other includes to pull it in.