### PR TITLE
tests: net: coap: re-enable general COAP tests

### DIFF
--- a/tests/net/coap/general/testcase.yaml
+++ b/tests/net/coap/general/testcase.yaml
@@ -13,7 +13,6 @@ tests:
       - netif
       - wifi
   net.coap.general.native:
-    build_only: true
     platform_allow:
       - native_sim
     integration_platforms:


### PR DESCRIPTION
`coap.me` is back online, re-enable the tests.