### PR TITLE
algorithm_runner: algorithms: add missing include

### DIFF
--- a/include/infuse/algorithm_runner/algorithms/demo.h
+++ b/include/infuse/algorithm_runner/algorithms/demo.h
@@ -15,6 +15,7 @@
 #include <zephyr/toolchain.h>
 
 #include <infuse/algorithm_runner/runner.h>
+#include <infuse/zbus/channels.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Add an include that is required for the header to work by itself.