### PR TITLE
rpc: commands: wifi_state: zero init status struct

### DIFF
--- a/subsys/rpc/commands/wifi_state.c
+++ b/subsys/rpc/commands/wifi_state.c
@@ -22,7 +22,7 @@ struct net_buf *rpc_command_wifi_state(struct net_buf *request)
 {
 	struct rpc_wifi_state_response rsp = {0};
 	struct net_if *iface = net_if_get_default();
-	struct wifi_iface_status status;
+	struct wifi_iface_status status = {0};
 	int rc;
 
 	if (iface == NULL) {


### PR DESCRIPTION
Zero initialise the status structure, since the implementations are not guaranteed to result in valid data otherwise. Fixes the command returning invalid `utf-8` strings due to the lack of trailing NULL characters.