### PR TITLE
task_runner: tasks: default alternate TDF loggers

### DIFF
--- a/include/infuse/task_runner/tasks/infuse_task_ids.h
+++ b/include/infuse/task_runner/tasks/infuse_task_ids.h
@@ -28,6 +28,8 @@ enum infuse_task_ids {
 	TASK_ID_GNSS = 4,
 	TASK_ID_NETWORK_SCAN = 5,
 	TASK_ID_BT_SCANNER = 6,
+	TASK_ID_TDF_LOGGER_ALT1 = 7,
+	TASK_ID_TDF_LOGGER_ALT2 = 8,
 };
 
 /**

--- a/include/infuse/task_runner/tasks/tdf_logger.h
+++ b/include/infuse/task_runner/tasks/tdf_logger.h
@@ -59,7 +59,7 @@ void task_tdf_logger_manual_run(uint8_t tdf_loggers, uint64_t timestamp, uint16_
 				    }}))
 
 /**
- * @brief TDF logger task
+ * @brief Generic TDF logger task
  *
  * @param define_mem Define memory (None required)
  * @param define_config Define task
@@ -68,6 +68,36 @@ void task_tdf_logger_manual_run(uint8_t tdf_loggers, uint64_t timestamp, uint16_
  */
 #define TDF_LOGGER_TASK(define_mem, define_config, custom_logger)                                  \
 	_TDF_LOGGER_TASK_INSTANCE("tdfl", TASK_ID_TDF_LOGGER, define_mem, define_config,           \
+				  custom_logger)
+
+/**
+ * @brief TDF logger task, alternate instance 1
+ *
+ * Behaves the exact same way as @ref TDF_LOGGER_TASK, but with a different task ID.
+ * This allows multiple instance of TDF logging to run concurrently with each other.
+ *
+ * @param define_mem Define memory (None required)
+ * @param define_config Define task
+ * @param custom_logger Callback for custom logging
+ * @param ... Compile-time argument unused
+ */
+#define TDF_LOGGER_ALT1_TASK(define_mem, define_config, custom_logger)                             \
+	_TDF_LOGGER_TASK_INSTANCE("tdfl1", TASK_ID_TDF_LOGGER_ALT1, define_mem, define_config,     \
+				  custom_logger)
+
+/**
+ * @brief TDF logger task, alternate instance 2
+ *
+ * Behaves the exact same way as @ref TDF_LOGGER_TASK, but with a different task ID.
+ * This allows multiple instance of TDF logging to run concurrently with each other.
+ *
+ * @param define_mem Define memory (None required)
+ * @param define_config Define task
+ * @param custom_logger Callback for custom logging
+ * @param ... Compile-time argument unused
+ */
+#define TDF_LOGGER_ALT2_TASK(define_mem, define_config, custom_logger)                             \
+	_TDF_LOGGER_TASK_INSTANCE("tdfl2", TASK_ID_TDF_LOGGER_ALT2, define_mem, define_config,     \
 				  custom_logger)
 
 #ifdef __cplusplus


### PR DESCRIPTION
Support multiple instances of TDF loggers by default. This allows multiple TDF logging task definitions to be running concurrently.