### PR TITLE
manifest: update sdk-nrf to `v3.0.2`

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -35,7 +35,7 @@ manifest:
           - zcbor
     - name: sdk-nrf
       path: modules/nrfconnect/sdk-nrf
-      revision: 68996b252e1faf4d63a65ba100310435eb7a4d92
+      revision: 83be98321a58fcc35ab738315c752e93f107ce56
       import: true
     - name: memfault-firmware-sdk
       path: modules/lib/memfault


### PR DESCRIPTION
Update our export of sdk-nrf and nrfxlib to version `v3.0.2`.
  https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/releases_and_maturity/releases/release-notes-3.0.0.html#