### PR TITLE
tdf: explicit encoding format parameter

### DIFF
--- a/doc/embedded/app_features/tdf.rst
+++ b/doc/embedded/app_features/tdf.rst
@@ -143,7 +143,7 @@ one base reading, and then a repeating array of differences on each field. For e
       } diffs[];
    } __packed;
 
-As long as the differences on each field fall within `int8_t` from the previous value, this can lead to
+As long as the differences on each field fall within ``int8_t`` from the previous value, this can lead to
 large packing efficiencies (75% in this example). The original values can be reconstructed as follows:
 
 .. code-block:: c
@@ -162,26 +162,26 @@ encoding.
    * - Enum
      - Input Type
      - Diff Type
-   * - :c:enumerator:`TDF_DIFF_16_8`
+   * - :c:enumerator:`TDF_DATA_FORMAT_DIFF_ARRAY_16_8`
      - ``uint16_t`` / ``int16_t``
      - ``int8_t``
-   * - :c:enumerator:`TDF_DIFF_32_8`
+   * - :c:enumerator:`TDF_DATA_FORMAT_DIFF_ARRAY_32_8`
      - ``uint32_t`` / ``int32_t``
      - ``int8_t``
-   * - :c:enumerator:`TDF_DIFF_32_16`
+   * - :c:enumerator:`TDF_DATA_FORMAT_DIFF_ARRAY_32_16`
      - ``uint32_t`` / ``int32_t``
      - ``int16_t``
 
 The input data type defines how the encoder views the TDF struct, for example with
-:c:enumerator:`TDF_DIFF_32_8` the encoder will interpret the input as ``uint32_t`` chunks.
+:c:enumerator:`TDF_DATA_FORMAT_DIFF_ARRAY_32_8` the encoder will interpret the input as ``uint32_t`` chunks.
 The diff type defines the maximum value difference between input chunks that can be
 encoded as a valid diff.
 
 Generally, the input data type will be self-evident from the TDF type being encoded. ``struct tdf_example``
-from above for example should use either :c:enumerator:`TDF_DIFF_32_8` or :c:enumerator:`TDF_DIFF_32_16`.
-The choice comes down to the expected differences between subsequent values. A larger diff type can
-handle larger differences without falling back to :c:enumerator:`TDF_ARRAY_TIME`, but consumes more size
-in the output buffer.
+from above for example should use either :c:enumerator:`TDF_DATA_FORMAT_DIFF_ARRAY_32_8` or
+:c:enumerator:`TDF_DATA_FORMAT_DIFF_ARRAY_32_16`. The choice comes down to the expected differences between
+subsequent values. A larger diff type can handle larger differences without falling back to
+:c:enumerator:`TDF_ARRAY_TIME`, but consumes more size in the output buffer.
 
 When a reading is of this type, an additional 3 byte header is present after the timestamp structure.
 

--- a/include/infuse/data_logger/high_level/tdf.h
+++ b/include/infuse/data_logger/high_level/tdf.h
@@ -71,7 +71,7 @@ enum tdf_data_logger_mask {
  * @param tdf_id TDF sensor ID
  * @param tdf_len Length of a single TDF
  * @param tdf_num Number of TDFs to add
- * @param diff_type TDF diff encoding mode
+ * @param format TDF data encoding format
  * @param time Epoch time associated with the first TDF. 0 for no timestamp.
  * @param period Time period between the TDF samples
  * @param data TDF data array
@@ -79,9 +79,9 @@ enum tdf_data_logger_mask {
  * @retval 0 On success
  * @retval -errno Error code from @a tdf_add or @a tdf_data_logger_flush on error
  */
-int tdf_data_logger_log_array_diff_dev(const struct device *dev, uint16_t tdf_id, uint8_t tdf_len,
-				       uint8_t tdf_num, uint8_t diff_type, uint64_t time,
-				       uint32_t period, const void *data);
+int tdf_data_logger_log_core_dev(const struct device *dev, uint16_t tdf_id, uint8_t tdf_len,
+				 uint8_t tdf_num, enum tdf_data_format format, uint64_t time,
+				 uint32_t period, const void *data);
 
 /**
  * @brief Add multiple TDFs to multiple data loggers
@@ -90,14 +90,14 @@ int tdf_data_logger_log_array_diff_dev(const struct device *dev, uint16_t tdf_id
  * @param tdf_id TDF sensor ID
  * @param tdf_len Length of a single TDF
  * @param tdf_num Number of TDFs to add
- * @param diff_type TDF diff encoding mode
+ * @param format TDF data encoding format
  * @param time Epoch time associated with the first TDF. 0 for no timestamp.
  * @param period Time period between the TDF samples
  * @param data TDF data array
  */
-void tdf_data_logger_log_array_diff(uint8_t logger_mask, uint16_t tdf_id, uint8_t tdf_len,
-				    uint8_t tdf_num, uint8_t diff_type, uint64_t time,
-				    uint32_t period, const void *data);
+void tdf_data_logger_log_core(uint8_t logger_mask, uint16_t tdf_id, uint8_t tdf_len,
+			      uint8_t tdf_num, enum tdf_data_format format, uint64_t time,
+			      uint32_t period, const void *data);
 
 /**
  * @brief Add multiple TDFs to a data logger
@@ -117,8 +117,8 @@ static inline int tdf_data_logger_log_array_dev(const struct device *dev, uint16
 						uint8_t tdf_len, uint8_t tdf_num, uint64_t time,
 						uint32_t period, const void *data)
 {
-	return tdf_data_logger_log_array_diff_dev(dev, tdf_id, tdf_len, tdf_num, TDF_DIFF_NONE,
-						  time, period, data);
+	return tdf_data_logger_log_core_dev(dev, tdf_id, tdf_len, tdf_num,
+					    TDF_DATA_FORMAT_TIME_ARRAY, time, period, data);
 }
 
 /**
@@ -136,8 +136,8 @@ static inline void tdf_data_logger_log_array(uint8_t logger_mask, uint16_t tdf_i
 					     uint8_t tdf_num, uint64_t time, uint32_t period,
 					     const void *data)
 {
-	tdf_data_logger_log_array_diff(logger_mask, tdf_id, tdf_len, tdf_num, TDF_DIFF_NONE, time,
-				       period, data);
+	tdf_data_logger_log_core(logger_mask, tdf_id, tdf_len, tdf_num, TDF_DATA_FORMAT_TIME_ARRAY,
+				 time, period, data);
 }
 
 /**
@@ -155,8 +155,8 @@ static inline void tdf_data_logger_log_array(uint8_t logger_mask, uint16_t tdf_i
 static inline int tdf_data_logger_log_dev(const struct device *dev, uint16_t tdf_id,
 					  uint8_t tdf_len, uint64_t time, const void *data)
 {
-	return tdf_data_logger_log_array_diff_dev(dev, tdf_id, tdf_len, 1, TDF_DIFF_NONE, time, 0,
-						  data);
+	return tdf_data_logger_log_core_dev(dev, tdf_id, tdf_len, 1, TDF_DATA_FORMAT_SINGLE, time,
+					    0, data);
 }
 
 /**
@@ -171,8 +171,8 @@ static inline int tdf_data_logger_log_dev(const struct device *dev, uint16_t tdf
 static inline void tdf_data_logger_log(uint8_t logger_mask, uint16_t tdf_id, uint8_t tdf_len,
 				       uint64_t time, const void *data)
 {
-	tdf_data_logger_log_array_diff(logger_mask, tdf_id, tdf_len, 1, TDF_DIFF_NONE, time, 0,
-				       data);
+	tdf_data_logger_log_core(logger_mask, tdf_id, tdf_len, 1, TDF_DATA_FORMAT_SINGLE, time, 0,
+				 data);
 }
 
 /**

--- a/include/infuse/task_runner/task.h
+++ b/include/infuse/task_runner/task.h
@@ -280,24 +280,23 @@ static inline bool task_schedule_tdf_requested(const struct task_schedule *sched
  * @param tdf_id TDF sensor ID
  * @param tdf_len Length of a single TDF
  * @param tdf_num Number of TDFs to log
- * @param diff_type TDF diff encoding mode
+ * @param format TDF encoding mode
  * @param time Epoch time associated with the first TDF. 0 for no timestamp.
  * @param period Time period between the TDF samples
  * @param data TDF data array
  */
-static inline void task_schedule_tdf_log_array_diff(const struct task_schedule *schedule,
-						    uint8_t tdf_mask, uint16_t tdf_id,
-						    uint8_t tdf_len, uint8_t tdf_num,
-						    uint8_t diff_type, uint64_t time,
-						    uint32_t period, const void *data)
+static inline void task_schedule_tdf_log_core(const struct task_schedule *schedule,
+					      uint8_t tdf_mask, uint16_t tdf_id, uint8_t tdf_len,
+					      uint8_t tdf_num, enum tdf_data_format format,
+					      uint64_t time, uint32_t period, const void *data)
 {
 	if (schedule->task_logging[0].tdf_mask & tdf_mask) {
-		tdf_data_logger_log_array_diff(schedule->task_logging[0].loggers, tdf_id, tdf_len,
-					       tdf_num, diff_type, time, period, data);
+		tdf_data_logger_log_core(schedule->task_logging[0].loggers, tdf_id, tdf_len,
+					 tdf_num, format, time, period, data);
 	}
 	if (schedule->task_logging[1].tdf_mask & tdf_mask) {
-		tdf_data_logger_log_array_diff(schedule->task_logging[1].loggers, tdf_id, tdf_len,
-					       tdf_num, diff_type, time, period, data);
+		tdf_data_logger_log_core(schedule->task_logging[1].loggers, tdf_id, tdf_len,
+					 tdf_num, format, time, period, data);
 	}
 }
 
@@ -318,8 +317,8 @@ static inline void task_schedule_tdf_log_array(const struct task_schedule *sched
 					       uint8_t tdf_num, uint64_t time, uint32_t period,
 					       const void *data)
 {
-	task_schedule_tdf_log_array_diff(schedule, tdf_mask, tdf_id, tdf_len, tdf_num,
-					 TDF_DIFF_NONE, time, period, data);
+	task_schedule_tdf_log_core(schedule, tdf_mask, tdf_id, tdf_len, tdf_num,
+				   TDF_DATA_FORMAT_TIME_ARRAY, time, period, data);
 }
 
 /**
@@ -336,8 +335,8 @@ static inline void task_schedule_tdf_log(const struct task_schedule *schedule, u
 					 uint16_t tdf_id, uint8_t tdf_len, uint64_t time,
 					 const void *data)
 {
-	task_schedule_tdf_log_array_diff(schedule, tdf_mask, tdf_id, tdf_len, 1, TDF_DIFF_NONE,
-					 time, 0, data);
+	task_schedule_tdf_log_core(schedule, tdf_mask, tdf_id, tdf_len, 1, TDF_DATA_FORMAT_SINGLE,
+				   time, 0, data);
 }
 
 /**

--- a/subsys/data_logger/high_level/tdf_data_logger.c
+++ b/subsys/data_logger/high_level/tdf_data_logger.c
@@ -221,13 +221,13 @@ int tdf_data_logger_remote_id_set(const struct device *dev, uint64_t remote_id)
 #endif /* TDF_REMOTE_SUPPORT */
 
 static int log_locked(const struct device *dev, uint16_t tdf_id, uint8_t tdf_len, uint8_t tdf_num,
-		      uint8_t diff_type, uint64_t time, uint32_t period, const void *mem)
+		      enum tdf_data_format format, uint64_t time, uint32_t period, const void *mem)
 {
 	struct tdf_logger_data *data = dev->data;
 	int rc;
 
 relog:
-	rc = tdf_add_diff(&data->tdf_state, tdf_id, tdf_len, tdf_num, time, period, mem, diff_type);
+	rc = tdf_add_core(&data->tdf_state, tdf_id, tdf_len, tdf_num, time, period, mem, format);
 	if (rc == -ENOMEM) {
 		LOG_DBG("%s no space, flush and retry", dev->name);
 		rc = flush_internal(dev, true);
@@ -247,7 +247,7 @@ relog:
 		/* Logging precomputed diffs from a point other that the start is currently
 		 * not supported.
 		 */
-		if (!(diff_type & TDF_DIFF_PRECOMPUTED)) {
+		if (!(format & TDF_DATA_FORMAT_DIFF_PRECOMPUTED)) {
 			goto relog;
 		}
 	}
@@ -262,9 +262,9 @@ relog:
 	return rc;
 }
 
-int tdf_data_logger_log_array_diff_dev(const struct device *dev, uint16_t tdf_id, uint8_t tdf_len,
-				       uint8_t tdf_num, uint8_t diff_type, uint64_t time,
-				       uint32_t period, const void *mem)
+int tdf_data_logger_log_core_dev(const struct device *dev, uint16_t tdf_id, uint8_t tdf_len,
+				 uint8_t tdf_num, enum tdf_data_format format, uint64_t time,
+				 uint32_t period, const void *mem)
 {
 	const struct tdf_logger_config *config = dev->config;
 	struct tdf_logger_data *data = dev->data;
@@ -288,14 +288,14 @@ int tdf_data_logger_log_array_diff_dev(const struct device *dev, uint16_t tdf_id
 	}
 
 	k_sem_take(&data->lock, K_FOREVER);
-	rc = log_locked(dev, tdf_id, tdf_len, tdf_num, diff_type, time, period, mem);
+	rc = log_locked(dev, tdf_id, tdf_len, tdf_num, format, time, period, mem);
 	k_sem_give(&data->lock);
 	return rc < 0 ? rc : 0;
 }
 
-void tdf_data_logger_log_array_diff(uint8_t logger_mask, uint16_t tdf_id, uint8_t tdf_len,
-				    uint8_t tdf_num, uint8_t diff_type, uint64_t time,
-				    uint32_t period, const void *data)
+void tdf_data_logger_log_core(uint8_t logger_mask, uint16_t tdf_id, uint8_t tdf_len,
+			      uint8_t tdf_num, enum tdf_data_format format, uint64_t time,
+			      uint32_t period, const void *data)
 {
 	const struct device *dev;
 
@@ -303,8 +303,8 @@ void tdf_data_logger_log_array_diff(uint8_t logger_mask, uint16_t tdf_id, uint8_
 	do {
 		dev = logger_mask_iter(&logger_mask);
 		if (dev) {
-			(void)tdf_data_logger_log_array_diff_dev(dev, tdf_id, tdf_len, tdf_num,
-								 diff_type, time, period, data);
+			(void)tdf_data_logger_log_core_dev(dev, tdf_id, tdf_len, tdf_num, format,
+							   time, period, data);
 		}
 	} while (dev);
 }
@@ -325,6 +325,8 @@ static void tdf_block_size_update(const struct device *logger, uint16_t block_si
 	const struct tdf_logger_config *config = dev->config;
 	struct tdf_logger_data *data = dev->data;
 	uint16_t limited = MIN(block_size, config->tdf_buffer_max_size);
+	bool is_diff;
+	uint8_t num;
 
 	k_sem_take(&data->lock, K_FOREVER);
 	LOG_DBG("%s: from %d to %d bytes", dev->name, data->tdf_state.buf.size, limited);
@@ -352,14 +354,15 @@ static void tdf_block_size_update(const struct device *logger, uint16_t block_si
 #endif /* TDF_REMOTE_SUPPORT */
 		/* Re-log pending TDF's into the same buffer, which will flush as appropriate */
 		while (tdf_parse(&state, &tdf) == 0) {
-			uint8_t num = tdf.data_type == TDF_DATA_TYPE_DIFF_ARRAY
-					      ? 1 + tdf.diff_info.num
-					      : tdf.tdf_num;
-			uint8_t diff_type = tdf.data_type == TDF_DATA_TYPE_DIFF_ARRAY
-						    ? TDF_DIFF_PRECOMPUTED | tdf.diff_info.type
-						    : TDF_DIFF_NONE;
+			is_diff = (tdf.data_type == TDF_DATA_FORMAT_DIFF_ARRAY_16_8) ||
+				  (tdf.data_type == TDF_DATA_FORMAT_DIFF_ARRAY_32_8) ||
+				  (tdf.data_type == TDF_DATA_FORMAT_DIFF_ARRAY_32_16);
+			num = is_diff ? 1 + tdf.diff_info.num : tdf.tdf_num;
+			if (is_diff) {
+				tdf.data_type |= TDF_DATA_FORMAT_DIFF_PRECOMPUTED;
+			}
 
-			(void)log_locked(dev, tdf.tdf_id, tdf.tdf_len, num, diff_type, tdf.time,
+			(void)log_locked(dev, tdf.tdf_id, tdf.tdf_len, num, tdf.data_type, tdf.time,
 					 tdf.period, tdf.data);
 		}
 	}

--- a/tests/bsim/bluetooth/task_runner/src/bt_scanner_runner.c
+++ b/tests/bsim/bluetooth/task_runner/src/bt_scanner_runner.c
@@ -266,7 +266,7 @@ static void main_bt_scanner_defer_logging(void)
 		return;
 	}
 	if ((parsed.tdf_id != TDF_INFUSE_BLUETOOTH_RSSI) ||
-	    (parsed.data_type != TDF_DATA_TYPE_TIME_ARRAY) ||
+	    (parsed.data_type != TDF_DATA_FORMAT_TIME_ARRAY) ||
 	    (parsed.tdf_len != sizeof(struct tdf_infuse_bluetooth_rssi)) || (parsed.time == 0)) {
 		FAIL("Unexpected TDF data\n");
 	}
@@ -309,7 +309,7 @@ static void main_bt_scanner_defer_filter(void)
 		return;
 	}
 	if ((parsed.tdf_id != TDF_INFUSE_BLUETOOTH_RSSI) ||
-	    (parsed.data_type != TDF_DATA_TYPE_TIME_ARRAY) ||
+	    (parsed.data_type != TDF_DATA_FORMAT_TIME_ARRAY) ||
 	    (parsed.tdf_len != sizeof(struct tdf_infuse_bluetooth_rssi)) || (parsed.time == 0)) {
 		FAIL("Unexpected TDF data\n");
 	}
@@ -353,7 +353,7 @@ static void main_bt_scanner_defer_filter_limit(void)
 		return;
 	}
 	if ((parsed.tdf_id != TDF_INFUSE_BLUETOOTH_RSSI) ||
-	    (parsed.data_type != TDF_DATA_TYPE_TIME_ARRAY) ||
+	    (parsed.data_type != TDF_DATA_FORMAT_TIME_ARRAY) ||
 	    (parsed.tdf_len != sizeof(struct tdf_infuse_bluetooth_rssi)) || (parsed.time == 0)) {
 		FAIL("Unexpected TDF data\n");
 	}

--- a/tests/subsys/data_logger/high_level/tdf_epacket/src/main.c
+++ b/tests/subsys/data_logger/high_level/tdf_epacket/src/main.c
@@ -230,9 +230,9 @@ ZTEST(tdf_data_logger, test_diff_size_change_decrease)
 	epacket_dummy_set_max_packet(CONFIG_EPACKET_PACKET_SIZE_MAX);
 
 	/* Log diff array, data size == (2 + 15) */
-	rc = tdf_data_logger_log_array_diff_dev(logger, TDF_RANDOM, sizeof(uint16_t),
-						ARRAY_SIZE(tdf_data), TDF_DIFF_16_8, 10000, 100,
-						tdf_data);
+	rc = tdf_data_logger_log_core_dev(logger, TDF_RANDOM, sizeof(uint16_t),
+					  ARRAY_SIZE(tdf_data), TDF_DATA_FORMAT_DIFF_ARRAY_16_8,
+					  10000, 100, tdf_data);
 	zassert_equal(0, rc);
 	zassert_is_null(k_fifo_get(sent_queue, K_MSEC(1)));
 
@@ -260,8 +260,7 @@ ZTEST(tdf_data_logger, test_diff_size_change_decrease)
 	zassert_equal(10000, parsed.time);
 	zassert_equal(100, parsed.period);
 	zassert_equal(2, parsed.tdf_len);
-	zassert_equal(TDF_DATA_TYPE_DIFF_ARRAY, parsed.data_type);
-	zassert_equal(TDF_DIFF_16_8, parsed.diff_info.type);
+	zassert_equal(TDF_DATA_FORMAT_DIFF_ARRAY_16_8, parsed.data_type);
 	/* There was not space for all the diffs */
 	zassert_equal(12, parsed.diff_info.num);
 


### PR DESCRIPTION
Rather than having a dedicated logging parameter for diff types, make it a generic argument that can accept other encodings as well.

Since `array_diff` is no longer the most specialised case, rename the core logging functions as `core` instead.

Encoded data formats are not changed with this commit.