### PR TITLE
manifest: update zephyr fork with nRF54 GRTC fix

### DIFF
--- a/apps/bluetooth/hci_spi/Kconfig
+++ b/apps/bluetooth/hci_spi/Kconfig
@@ -10,9 +10,6 @@ configdefault IMG_MANAGER
 configdefault INFUSE_CPATCH
 	default y if BOOTLOADER_MCUBOOT
 
-configdefault NRF_GRTC_CLEAR_AT_INIT
-	default y
-
 config HEAP_MEM_POOL_ADD_SIZE_HCI_IPC
 	int "Heap size required by IPC library"
 	depends on DT_HAS_ZEPHYR_BT_HCI_IPC_ENABLED

--- a/kconfig/Kconfig.defaults.nrf
+++ b/kconfig/Kconfig.defaults.nrf
@@ -5,10 +5,6 @@ if SOC_FAMILY_NORDIC_NRF
 configdefault NRF_CC3XX_PLATFORM
 	default y
 
-# Fix uptime not resetting on reboot (We don't use the RTC)
-configdefault NRF_GRTC_CLEAR_AT_INIT
-	default y
-
 # Use CC3XX platform
 choice MBEDTLS_PSA_CRYPTO_RNG_SOURCE
 	default MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG if NRF_CC3XX_PLATFORM

--- a/west.yml
+++ b/west.yml
@@ -12,7 +12,7 @@ manifest:
 
   projects:
     - name: zephyr
-      revision: 7bfc22edf91dfb6eea29d6c9c1696e8e261fd391
+      revision: b2d53a190a7b68609a4835263504eacb92254048
       # Limit imported repositories to reduce clone time
       import:
         name-allowlist:


### PR DESCRIPTION
Update the Zephyr fork to fix the nRF54 uptime not resetting across reboots.