### PR TITLE
epacket: interfaces: bt_adv: reduce maximum packet len

### DIFF
--- a/dts/bindings/epacket/embeint,epacket_bt_adv.yaml
+++ b/dts/bindings/epacket/embeint,epacket_bt_adv.yaml
@@ -11,7 +11,7 @@ properties:
   depends-on:
     default: "CONFIG_EPACKET_INTERFACE_BT_ADV"
   max-packet-size:
-    default: 113
+    default: 103
   header-size:
     default: 23
   footer-size:

--- a/subsys/epacket/interfaces/epacket_bt_adv.c
+++ b/subsys/epacket/interfaces/epacket_bt_adv.c
@@ -232,7 +232,7 @@ static const struct epacket_interface_api bt_adv_api = {
 	.receive_ctrl = epacket_bt_adv_receive_control,
 };
 
-BUILD_ASSERT(113 == DT_INST_PROP(0, max_packet_size));
+BUILD_ASSERT(103 == DT_INST_PROP(0, max_packet_size));
 static struct epacket_interface_common_data epacket_bt_adv_data;
 static const struct epacket_interface_common_config epacket_bt_adv_config = {
 	.max_packet_size = EPACKET_INTERFACE_MAX_PACKET(DT_DRV_INST(0)),

--- a/subsys/epacket/interfaces/epacket_bt_adv_crypt.c
+++ b/subsys/epacket/interfaces/epacket_bt_adv_crypt.c
@@ -17,7 +17,7 @@
 #include "epacket_internal.h"
 
 #define EMBEINT_COMPANY_CODE 0x0DE4
-#define BT_MFG_DATA_LEN      113
+#define BT_MFG_DATA_LEN      103
 
 static struct {
 	uint16_t company_code;
@@ -26,9 +26,11 @@ static struct {
 
 /* Maximum serialized data structure length is 124 bytes in order to be
  * received by iOS devices. Layout:
- *                Flags = (2 + 1) bytes
- *         Service UUID = (2 + 2) bytes
- *    Manufacturer Data = (2 + 2 + 113) bytes
+ *    Extended Advertising Header = 10 bytes
+ *    AD Structures:
+ *                          Flags = (2 + 1) bytes
+ *                   Service UUID = (2 + 2) bytes
+ *              Manufacturer Data = (2 + 2 + 103) bytes
  */
 static struct bt_data ad_structures[] = {
 	/* From BT Core Specification Supplement v11:


### PR DESCRIPTION
Reduce the maximum packet size on this interface to ensure compatibility with iOS. The limit of 124 bytes was originally understood to be 124 bytes of AD data, but it actually includes the 10 byte extended advertising header.