### PR TITLE
manifest: update zephyr fork

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -12,7 +12,7 @@ manifest:
 
   projects:
     - name: zephyr
-      revision: 9899dd36f1d902a864f92866b9703493f000caa1
+      revision: 513a13fd2b99c6b3562eac2d5fec139894ee1ca4
       # Limit imported repositories to reduce clone time
       import:
         name-allowlist:


### PR DESCRIPTION
Update zephyr fork to fix the default pin state of the NRF SPIM peripheral after boot.