### PR TITLE
nrf_modem_monitor: configurable PDP protocol family

### DIFF
--- a/lib/nrf_modem_lib/Kconfig
+++ b/lib/nrf_modem_lib/Kconfig
@@ -53,6 +53,25 @@ config INFUSE_NRF_MODEM_MONITOR_DEFAULT_PDP_APN_SET
 	bool
 	default y if INFUSE_NRF_MODEM_MONITOR_DEFAULT_PDP_APN != ""
 
+choice INFUSE_NRF_MODEM_MONITOR_DEFAULT_PDP_FAMILY
+	prompt "Default protocol family to use for PDP context 0"
+	depends on INFUSE_NRF_MODEM_MONITOR_DEFAULT_PDP_APN_SET
+	default INFUSE_NRF_MODEM_MONITOR_DEFAULT_PDP_FAMILY_IPV4V6
+
+config INFUSE_NRF_MODEM_MONITOR_DEFAULT_PDP_FAMILY_IPV4
+	bool "Internet Protocol"
+
+config INFUSE_NRF_MODEM_MONITOR_DEFAULT_PDP_FAMILY_IPV6
+	bool "Internet Protocol version 6"
+
+config INFUSE_NRF_MODEM_MONITOR_DEFAULT_PDP_FAMILY_IPV4V6
+	bool "Virtual type of dual IP stack"
+
+config INFUSE_NRF_MODEM_MONITOR_DEFAULT_PDP_FAMILY_NON_IP
+	bool "Transfer of non-IP data to external packet data network"
+
+endchoice
+
 config INFUSE_NRF_MODEM_MONITOR_AT_TIMEOUT_MS
 	int "Timeout period for nRF modem AT commands"
 	default 100

--- a/lib/nrf_modem_lib/nrf_modem_monitor.c
+++ b/lib/nrf_modem_lib/nrf_modem_monitor.c
@@ -398,7 +398,17 @@ static void infuse_modem_init(int ret, void *ctx)
 					strlen(CONFIG_INFUSE_NRF_MODEM_MONITOR_DEFAULT_PDP_APN) + 1,
 				.value = CONFIG_INFUSE_NRF_MODEM_MONITOR_DEFAULT_PDP_APN,
 			},
+#if defined(CONFIG_INFUSE_NRF_MODEM_MONITOR_DEFAULT_PDP_FAMILY_IPV4)
 		.family = PDN_FAM_IPV4,
+#elif defined(CONFIG_INFUSE_NRF_MODEM_MONITOR_DEFAULT_PDP_FAMILY_IPV6)
+		.family = PDN_FAM_IPV6,
+#elif defined(CONFIG_INFUSE_NRF_MODEM_MONITOR_DEFAULT_PDP_FAMILY_IPV4V6)
+		.family = PDN_FAM_IPV4V6,
+#elif defined(CONFIG_INFUSE_NRF_MODEM_MONITOR_DEFAULT_PDP_FAMILY_NON_IP)
+		.family = PDN_FAM_NONIP,
+#else
+#error "Unknown protocol family"
+#endif
 	};
 
 	/* Read the configured value, falling back to the default */

--- a/tests/net/nrf_modem_lib/src/main.c
+++ b/tests/net/nrf_modem_lib/src/main.c
@@ -208,14 +208,14 @@ ZTEST(infuse_nrf_modem_monitor, test_integration)
 	zassert_equal(LTE_LC_SYSTEM_MODE_LTEM_NBIOT_GPS, net_modes.modes);
 	zassert_equal(CONFIG_LTE_MODE_PREFERENCE_VALUE, net_modes.prefer);
 	kv_store_read(KV_KEY_LTE_PDP_CONFIG, &pdp_config, sizeof(pdp_config));
-	zassert_equal(PDN_FAM_IPV4, pdp_config.family);
+	zassert_equal(PDN_FAM_IPV4V6, pdp_config.family);
 	zassert_mem_equal(CONFIG_INFUSE_NRF_MODEM_MONITOR_DEFAULT_PDP_APN, pdp_config.apn.value,
 			  strlen(CONFIG_INFUSE_NRF_MODEM_MONITOR_DEFAULT_PDP_APN));
 
 	nrf_modem_lib_sim_default_pdn_ctx(&default_apn, &default_family);
 	zassert_mem_equal(CONFIG_INFUSE_NRF_MODEM_MONITOR_DEFAULT_PDP_APN, default_apn,
 			  strlen(CONFIG_INFUSE_NRF_MODEM_MONITOR_DEFAULT_PDP_APN));
-	zassert_equal(PDN_FAM_IPV4, default_family);
+	zassert_equal(PDN_FAM_IPV4V6, default_family);
 
 	nrf_modem_monitor_network_state(&net_state);
 	zassert_equal(LTE_LC_NW_REG_NOT_REGISTERED, net_state.nw_reg_status);


### PR DESCRIPTION
Make the default protocol family of PDP context 0 configurable through Kconfig.