### PR TITLE
Use secure randomness for network key generator

### DIFF
--- a/doc/tooling/python/python_credentials.rst
+++ b/doc/tooling/python/python_credentials.rst
@@ -46,7 +46,7 @@ credential manager. This only needs to be performed once per install.
 
     infuse credentials --network-key /path/to/network_key.yaml
 
-New network key files can be generated with the ``infuse-sdk/scripts/network_key_gen.py`` helper.
+New network key files can be generated with the ``infuse-sdk/scripts/network_key_gen.py`` helper, which uses a cryptographically secure random number generator.
 
 .. note::
 

--- a/scripts/network_key_gen.py
+++ b/scripts/network_key_gen.py
@@ -2,7 +2,7 @@
 
 import argparse
 import pathlib
-import random
+import secrets
 import sys
 import yaml
 
@@ -29,7 +29,7 @@ if __name__ == "__main__":
 
     contents = {
         "id": args.id,
-        "key": random.randbytes(32),
+        "key": secrets.token_bytes(32),
     }
     yaml.add_representer(int, hexint_presenter)
 


### PR DESCRIPTION
## Summary
- Replace `random.randbytes` with `secrets.token_bytes` in network key generator
- Document secure RNG usage in network key generation instructions

## Testing
- `python3 scripts/network_key_gen.py --id 0xabcdef test_network_key.yaml`
- `python3 -m py_compile scripts/network_key_gen.py`


------
https://chatgpt.com/codex/tasks/task_b_6894555f65e883278b587035d1b5030b