### PR TITLE
manifest: update `sdk-nrf`

### DIFF
--- a/.github/workflows/twister.yml
+++ b/.github/workflows/twister.yml
@@ -128,8 +128,10 @@ jobs:
         name: Run Vendor Tests with Twister (Daily)
         run: |
           export ZEPHYR_BASE=${PWD}/zephyr
-          echo 'twister ${TWISTER_COMMON} ${VENDOR_FILTER} ${DAILY_OPTIONS} -T infuse-sdk'
-          $ZEPHYR_BASE/scripts/twister --subset ${{matrix.subset}}/${{ strategy.job-total }} ${TWISTER_COMMON} ${VENDOR_FILTER} ${DAILY_OPTIONS} --all -T infuse-sdk
+          echo 'twister ${TWISTER_COMMON} ${VENDOR_FILTER} ${DAILY_OPTIONS} --all -T infuse-sdk/apps -T infuse-sdk/samples'
+          $ZEPHYR_BASE/scripts/twister --subset ${{matrix.subset}}/${{ strategy.job-total }} ${TWISTER_COMMON} ${VENDOR_FILTER} ${DAILY_OPTIONS} --all -T infuse-sdk/apps -T infuse-sdk/samples
+          echo 'twister ${TWISTER_COMMON} ${VENDOR_FILTER} ${DAILY_OPTIONS} -T infuse-sdk/tests'
+          $ZEPHYR_BASE/scripts/twister --subset ${{matrix.subset}}/${{ strategy.job-total }} ${TWISTER_COMMON} ${VENDOR_FILTER} ${DAILY_OPTIONS} -T infuse-sdk/tests
 
       - name: Print ccache stats
         if: always()

--- a/west.yml
+++ b/west.yml
@@ -36,7 +36,7 @@ manifest:
           - zcbor
     - name: sdk-nrf
       path: modules/nrfconnect/sdk-nrf
-      revision: c8b5f3902259f530679bbb4dd4c1af7f0cfd431f
+      revision: d978704fbd020ab9ce34f122ad9a499bb0744f42
       import: true
     - name: memfault-firmware-sdk
       path: modules/lib/memfault


### PR DESCRIPTION
Update `sdk-nrf` to ensure that peripherals (PPI channels) reserved by the Softdevice/MPSL are not handed out by Zephyr drivers. This resolves interrupt driven UART failing when used with the Softdevice.