### PR TITLE
manifest: update sdk-nrf to `v3.1.0`

### DIFF
--- a/lib/memfault/infuse_metrics.c
+++ b/lib/memfault/infuse_metrics.c
@@ -38,6 +38,7 @@ int memfault_platform_get_stateofcharge(sMfltPlatformBatterySoc *soc)
 #include <infuse/lib/nrf_modem_monitor.h>
 
 #include <modem/lte_lc.h>
+#include <modem/nrf_modem_lib.h>
 
 static void memfault_lte_event_handler(const struct lte_lc_evt *const evt)
 {
@@ -83,7 +84,7 @@ static void memfault_lte_event_handler(const struct lte_lc_evt *const evt)
 	}
 }
 
-static void memfault_lte_mode_cb(enum lte_lc_func_mode mode, void *ctx)
+static void memfault_lte_mode_cb(int mode, void *ctx)
 {
 	switch (mode) {
 	case LTE_LC_FUNC_MODE_NORMAL:
@@ -109,7 +110,7 @@ static void memfault_lte_mode_cb(enum lte_lc_func_mode mode, void *ctx)
 	}
 }
 
-LTE_LC_ON_CFUN(memfault_lte_mode_cb, memfault_lte_mode_cb, NULL);
+NRF_MODEM_LIB_ON_CFUN(memfault_lte_mode_cb, memfault_lte_mode_cb, NULL);
 
 void memfault_platform_metrics_connectivity_boot(void)
 {

--- a/lib/nrf_modem_lib/nrf_modem_lib_sim.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib_sim.c
@@ -10,6 +10,7 @@
 
 #include <zephyr/logging/log.h>
 
+#include <nrf_socket.h>
 #include <nrf_modem.h>
 #include <nrf_modem_at.h>
 #include <modem/lte_lc.h>
@@ -48,6 +49,24 @@ int nrf_modem_lib_init(void)
 		e->callback(err, e->context);
 	}
 	return 0;
+}
+
+int nrf_setdnsaddr(int family, const void *in_addr, nrf_socklen_t in_size)
+{
+	ARG_UNUSED(family);
+	ARG_UNUSED(in_addr);
+	ARG_UNUSED(in_size);
+
+	return -1;
+}
+
+int nrf_inet_pton(int af, const char *src, void *dst)
+{
+	ARG_UNUSED(af);
+	ARG_UNUSED(src);
+	ARG_UNUSED(dst);
+
+	return -1;
 }
 
 int nrf_modem_at_notif_handler_set(nrf_modem_at_notif_handler_t callback)

--- a/west.yml
+++ b/west.yml
@@ -36,7 +36,7 @@ manifest:
           - zcbor
     - name: sdk-nrf
       path: modules/nrfconnect/sdk-nrf
-      revision: d978704fbd020ab9ce34f122ad9a499bb0744f42
+      revision: 5846222d83692708d37b35a1a729a052acbe4ab6
       import: true
     - name: memfault-firmware-sdk
       path: modules/lib/memfault


### PR DESCRIPTION
Update our `sdk-nrf` export to be based from `v3.1.0`. Primarily this fixes an issue with Bluetooth gateway scanning stopping forever if an extended advertising packet with an AUX offset of 0 is observed.