### PR TITLE
gnss: ubx: decouple headers from Zephyr

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -283,6 +283,7 @@ jobs:
       - name: Move coverage files
         run: |
           mv ./coverage/reports/*/*.json ./coverage/reports
+          rm -f ./coverage/reports/merged.json
           ls -la ./coverage/reports
 
       - name: Generate list of coverage files

--- a/drivers/gnss/gnss_ubx_modem.c
+++ b/drivers/gnss/gnss_ubx_modem.c
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: FSL-1.1-ALv2
  */
 
-#include <zephyr/modem/ubx.h>
 #include <zephyr/logging/log.h>
 
 #include <infuse/gnss/ubx/protocol.h>

--- a/include/infuse/gnss/ubx/modem.h
+++ b/include/infuse/gnss/ubx/modem.h
@@ -14,8 +14,9 @@
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/modem/pipe.h>
-#include <zephyr/modem/ubx.h>
 #include <zephyr/sys/ring_buffer.h>
+
+#include <infuse/gnss/ubx/protocol.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/kconfig/Kconfig.defaults.core
+++ b/kconfig/Kconfig.defaults.core
@@ -224,8 +224,6 @@ configdefault UART_USE_RUNTIME_CONFIGURE
 	default n
 
 # Debug options
-configdefault DEBUG_INFO
-	default y
 configdefault DEBUG_THREAD_INFO
 	default y
 configdefault OUTPUT_DISASSEMBLY

--- a/subsys/mgmt/mcumgr/os_mgmt_infuse/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/os_mgmt_infuse/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library(mgmt_mcumgr_grp_os)
+zephyr_library()
 zephyr_library_sources(os_mgmt_infuse.c)
 
 if (CONFIG_BOOTLOADER_MCUBOOT)


### PR DESCRIPTION
Decouple our UBX headers from the Zephyr headers, to prevent breakage when the upstream implementation changes.