### PR TITLE
apps: update testcases using shields

### DIFF
--- a/apps/data_logger/sample.yaml
+++ b/apps/data_logger/sample.yaml
@@ -18,24 +18,14 @@ tests:
       - tauro/nrf9151/ns
   sample.app.data_logger.wifi:
     tags: app
-    extra_args:
-      - SHIELD=nrf7002eb
-      - EXTRA_DTC_OVERLAY_FILE=boards/shields/epacket_udp.overlay
-    extra_configs:
-      - CONFIG_LOG=n
-    platform_allow:
-      - thingy53/nrf5340/cpuapp/ns
-      - thingy53/nrf5340/cpuapp
-    integration_platforms:
-      - thingy53/nrf5340/cpuapp/ns
-  sample.app.data_logger.wifi.sysbuild:
-    tags: app
     sysbuild: true
     filter: not CONFIG_BUILD_WITH_TFM
     extra_args:
       - data_logger_SHIELD=nrf7002eb
       - data_logger_EXTRA_DTC_OVERLAY_FILE=boards/shields/epacket_udp.overlay
     platform_allow:
+      - thingy53/nrf5340/cpuapp/ns
       - thingy53/nrf5340/cpuapp
     integration_platforms:
+      - thingy53/nrf5340/cpuapp/ns
       - thingy53/nrf5340/cpuapp

--- a/apps/lte_tracker/sample.yaml
+++ b/apps/lte_tracker/sample.yaml
@@ -23,6 +23,7 @@ tests:
     tags: app
   sample.app.lte_tracker.wifi_scanner:
     tags: app
+    sysbuild: true
     extra_args:
-      - EXTRA_CONF_FILE=wifi_scanning.conf
-      - SHIELD=nrf7002ek
+      - lte_tracker_SHIELD=nrf7002ek
+      - lte_tracker_EXTRA_CONF_FILE=wifi_scanning.conf

--- a/samples/epacket/udp_bulk_upload/sample.yaml
+++ b/samples/epacket/udp_bulk_upload/sample.yaml
@@ -14,8 +14,9 @@ tests:
       - nrf7002dk/nrf5340/cpuapp
   sample.epacket.udp_bulk_upload.nrf7002eb:
     tags: net epacket
+    sysbuild: true
     platform_allow:
       - thingy53/nrf5340/cpuapp
     extra_args:
-      - SHIELD=nrf7002eb
-      - EXTRA_DTC_OVERLAY_FILE=epacket_udp.overlay
+      - udp_bulk_upload_SHIELD=nrf7002eb
+      - udp_bulk_upload_EXTRA_DTC_OVERLAY_FILE=epacket_udp.overlay

--- a/samples/task_runner/gnss/sample.yaml
+++ b/samples/task_runner/gnss/sample.yaml
@@ -20,8 +20,9 @@ tests:
       - CONFIG_GNSS_U_BLOX_NO_API_COMPAT=n
   sample.task_runner.gnss.sparkfun:
     tags: app
-    platform_allow:
-      - nrf52840dk/nrf52840
+    sysbuild: true
+    depends_on: arduino_i2c
     integration_platforms:
       - nrf52840dk/nrf52840
-    extra_args: SHIELD=sparkfun_sam_m10
+    extra_args:
+      - task_runner_gnss_SHIELD=sparkfun_sam_m10

--- a/tests/drivers/gnss/testcase.yaml
+++ b/tests/drivers/gnss/testcase.yaml
@@ -5,9 +5,10 @@ sample:
 tests:
   sample.gnss.sparkfun_sam_m10q:
     build_only: true
+    sysbuild: true
+    extra_args:
+      - gnss_SHIELD=sparkfun_sam_m10
     platform_allow:
       - nrf52840dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
-    extra_args:
-      - SHIELD=sparkfun_sam_m10

--- a/tests/subsys/data_logger/backends/exfat_multi_file/CMakeLists.txt
+++ b/tests/subsys/data_logger/backends/exfat_multi_file/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(data_logger)
+project(exfat_multi_file)
 
 target_sources(app PRIVATE
   src/main.c

--- a/tests/subsys/data_logger/backends/exfat_multi_file/testcase.yaml
+++ b/tests/subsys/data_logger/backends/exfat_multi_file/testcase.yaml
@@ -18,9 +18,10 @@ tests:
       - CONFIG_PM_DEVICE_RUNTIME=y
   data_logger.exfat_multi.sd:
     build_only: true
+    sysbuild: true
     depends_on: arduino_spi
     extra_args:
-      - SHIELD=sparkfun_microsd
+      - exfat_multi_file_SHIELD=sparkfun_microsd
     # Shield will fail to compile on any board with an existing SPI device
     # on the Arduino SPI bus. Limit testing to a board we know without this
     # problem.


### PR DESCRIPTION
Force sysbuild to be enabled for samples that specify shields, as the form of the `SHIELD=` command needs to change for sysbuild builds, and boards can opt themselves into forcing sysbuild without a way for `testcase.yaml` to disable it.