### PR TITLE
manifest: update zephyr fork

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -12,7 +12,7 @@ manifest:
 
   projects:
     - name: zephyr
-      revision: 89c345195f7afb406bf1bbfb23195aaa69f07639
+      revision: 3adee498273dd5f86f038c65fcd7e9347fd14f77
       # Limit imported repositories to reduce clone time
       import:
         name-allowlist:


### PR DESCRIPTION
Update zephyr fork to fix coverage dumps failing when any PM option is enabled.