### PR TITLE
dfu: helpers: chunks flash area erase

### DIFF
--- a/include/infuse/dfu/helpers.h
+++ b/include/infuse/dfu/helpers.h
@@ -29,12 +29,14 @@ extern "C" {
  *
  * @param fa Flash area to erase (must be already opened)
  * @param image_len Length of image
+ * @param progress_callback Optional progress callback
  * @param mcuboot_trailer Erase space for MCUBoot trailer
  *
  * @retval 0 On success
  * @retval -errno Error code from @a flash_area_erase on failure
  */
-int infuse_dfu_image_erase(const struct flash_area *fa, size_t image_len, bool mcuboot_trailer);
+int infuse_dfu_image_erase(const struct flash_area *fa, size_t image_len,
+			   void (*progress_callback)(uint32_t offset), bool mcuboot_trailer);
 
 /**
  * @brief Prepare the nRF91 modem for a delta image upgrade

--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -6,12 +6,22 @@ config INFUSE_DFU_HELPERS
 	depends on FLASH_PAGE_LAYOUT
 	default y if MCUBOOT_IMG_MANAGER || INFUSE_RPC_COMMAND_BT_FILE_COPY_BASIC || SOC_SERIES_BSIM_NRFXX
 
+if INFUSE_DFU_HELPERS
+
+config INFUSE_DFU_HELPERS_ERASE_CHUNK_SIZE
+	int "Number of bytes to erase in each call to `flash_area_flatten`"
+	default 65536
+	help
+	  Erasing a large flash area can take a long time, break up large erases into
+	  chunks of this size to provide an opportunity for watchdogs to be fed.
+
 config INFUSE_DFU_EXFAT
 	bool "Upgrade application images from an exFAT filesystem"
-	depends on INFUSE_DFU_HELPERS
 	depends on MCUBOOT_IMG_MANAGER
 	depends on DATA_LOGGER_EXFAT
 	default y
 	help
 	  Enable functions to automate the process of upgrading firmware from a
 	  /dfu folder on a mounted filesystem.
+
+endif # INFUSE_DFU_HELPERS

--- a/subsys/dfu/dfu_exfat.c
+++ b/subsys/dfu/dfu_exfat.c
@@ -147,7 +147,7 @@ int dfu_exfat_app_upgrade_copy(const struct device *dev, struct infuse_version u
 	}
 
 	/* Erase output area */
-	if (infuse_dfu_image_erase(fa, fno.fsize, true) != 0) {
+	if (infuse_dfu_image_erase(fa, fno.fsize, NULL, true) != 0) {
 		rc = -EIO;
 		goto close_area;
 	}


### PR DESCRIPTION
Erase the flash area in `infuse_dfu_image_erase` in chunks, allowing for callers to receive a callback to feed watchdogs while erasing. This fixes watchdog timeouts while erasing onboard flash on nRF54L's, which can be slow if Bluetooth is running.