### PR TITLE
manifest: update zephyr fork

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Set up ccache
         run: |
           mkdir -p ${CCACHE_DIR}
-          ccache -M 10G
+          ccache -M 20G
           ccache -p
           ccache -z -s -vv
 
@@ -237,7 +237,7 @@ jobs:
       - name: Set up ccache
         run: |
           mkdir -p ${CCACHE_DIR}
-          ccache -M 10G
+          ccache -M 20G
           ccache -p
           ccache -z -s -vv
 

--- a/.github/workflows/twister.yml
+++ b/.github/workflows/twister.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Set up ccache
         run: |
           mkdir -p ${CCACHE_DIR}
-          ccache -M 10G
+          ccache -M 20G
           ccache -p
           ccache -z -s -vv
 

--- a/.github/workflows/twister.yml
+++ b/.github/workflows/twister.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       CCACHE_DIR: /github/ccache
       # `--specs` is ignored because ccache is unable to resolve the toolchain specs file path.
-      CCACHE_IGNOREOPTIONS: '--specs=*'
+      CCACHE_IGNOREOPTIONS: '-specs=* --specs=*'
       # Ignore nrf54l09pdk until upgrading to Zephyr v4.2, v4.1 and HAL v3.12.0 are incompatible
       TWISTER_COMMON: ' --force-color --inline-logs -v -N -M --retry-failed 3 -P nrf54l09pdk/nrf54l09/cpuapp -P nrf54l20pdk/nrf54l20/cpuapp'
       DAILY_OPTIONS: ' -M --build-only --show-footprint'

--- a/west.yml
+++ b/west.yml
@@ -12,7 +12,7 @@ manifest:
 
   projects:
     - name: zephyr
-      revision: 2dd8de3d7a6dbd2da1f9cb157ef70c9ed694d858
+      revision: e75e65801c4c732bff16cb22ec336b55fa1ed4de
       # Limit imported repositories to reduce clone time
       import:
         name-allowlist:


### PR DESCRIPTION
Update zephyr fork to fix an issue that lead to ccache being ignored for all applications and tests built with picolibc.