### PR TITLE
scripts: cloud_definitions: rpc: add `counted_by`

### DIFF
--- a/scripts/west_commands/cloud_definitions/rpc.json
+++ b/scripts/west_commands/cloud_definitions/rpc.json
@@ -14,7 +14,7 @@
             "fields": [
                 {"name": "id", "type": "uint16_t"},
                 {"name": "len", "type": "int16_t"},
-                {"name": "data", "type": "uint8_t", "num": 0}
+                {"name": "data", "type": "uint8_t", "num": 0, "counted_by": "len"}
             ]
         },
         "rpc_struct_kv_store_crc": {
@@ -98,7 +98,7 @@
                 {"name": "rssi", "type": "int8_t", "description": "Received signal strength (dBm)"},
                 {"name": "bssid", "type": "uint8_t", "num": 6, "description": "Basic Service Set Identifier (MAC address)"},
                 {"name": "ssid_len", "type": "uint8_t", "description": "SSID length"},
-                {"name": "ssid", "type": "char", "num": 0, "description": "Service Set Identifier (Network Name)"}
+                {"name": "ssid", "type": "char", "num": 0, "counted_by": "ssid_len", "description": "Service Set Identifier (Network Name)"}
             ]
         },
         "rpc_struct_xyz_s16": {

--- a/scripts/west_commands/templates/rpc_definitions.py.jinja
+++ b/scripts/west_commands/templates/rpc_definitions.py.jinja
@@ -44,6 +44,7 @@ class {{ name }}(enum.IntEnum):
 {% endfor -%}
 
 class RPCDefinitionBase:
+    NAME: str
     HELP: str
     DESCRIPTION: str
     COMMAND_ID: int
@@ -54,6 +55,7 @@ class RPCDefinitionBase:
 class {{ info['name'] }}(RPCDefinitionBase):
     """{{ info['description'] }}"""
 
+    NAME = "{{ info['name'] }}"
     HELP = "{{ info['description'] }}"
     DESCRIPTION = "{{ info['description'] }}"
     COMMAND_ID = {{ command_id }}

--- a/scripts/west_commands/templates/rpc_definitions.py.jinja
+++ b/scripts/west_commands/templates/rpc_definitions.py.jinja
@@ -42,10 +42,16 @@ class {{ name }}(enum.IntEnum):
 
 {% endif %}
 {% endfor -%}
+
+class RPCDefinitionBase:
+    HELP: str
+    DESCRIPTION: str
+    COMMAND_ID: int
+
 {% for command_id, info in commands.items() %}
 {% if extensions == info.get('extension', False) %}
 
-class {{ info['name'] }}:
+class {{ info['name'] }}(RPCDefinitionBase):
     """{{ info['description'] }}"""
 
     HELP = "{{ info['description'] }}"
@@ -81,8 +87,16 @@ class {{ info['name'] }}:
 {% endif %}
 {% endfor -%}
 
+id_type_mapping: dict[int, type[RPCDefinitionBase]] = {
+{% for command_id, info in commands.items() %}
+{% if extensions == info.get('extension', False) %}
+    {{ info['name'] | lower }}.COMMAND_ID: {{ info['name'] | lower }},
+{% endif %}
+{% endfor %}
+}
 
 __all__ = [
+      'id_type_mapping',
 {% for name, info in structs.items() %}
 {% if extensions == info.get('extension', False) %}
     '{{ name }}',


### PR DESCRIPTION
Add the `counted_by` field to nested RPC structs that have a variable
length array. This is required for generic parsers to know how many
bytes should be allocated to this particular struct vs any remaining
structs.

Naming matches the experimental C attribute from GCC and Clang.