### PR TITLE
gnss: u_blox: explicit log levels

### DIFF
--- a/drivers/gnss/gnss_u_blox_m10_i2c.c
+++ b/drivers/gnss/gnss_u_blox_m10_i2c.c
@@ -42,7 +42,7 @@ struct ubx_m10_i2c_data {
 
 BUILD_ASSERT(__alignof(struct ubx_frame) == 1);
 
-LOG_MODULE_DECLARE(ubx_modem);
+LOG_MODULE_DECLARE(ubx_modem, CONFIG_GNSS_UBX_MODEM_LOG_LEVEL);
 
 #ifndef CONFIG_GNSS_U_BLOX_NO_API_COMPAT
 

--- a/drivers/gnss/gnss_u_blox_m8_emul.c
+++ b/drivers/gnss/gnss_u_blox_m8_emul.c
@@ -40,7 +40,7 @@ struct emul_data {
 	sys_slist_t handlers;
 };
 
-LOG_MODULE_REGISTER(ubx_m8_emul, LOG_LEVEL_INF);
+LOG_MODULE_REGISTER(ubx_m8_emul, CONFIG_GNSS_UBX_MODEM_LOG_LEVEL);
 
 static void message_dispatch(struct emul_data *data, uint8_t msg_class, uint8_t msg_id, void *msg,
 			     size_t msg_len)

--- a/drivers/gnss/gnss_u_blox_m8_spi.c
+++ b/drivers/gnss/gnss_u_blox_m8_spi.c
@@ -42,7 +42,7 @@ struct ubx_m8_spi_data {
 	struct modem_backend_ublox_spi spi_backend;
 };
 
-LOG_MODULE_DECLARE(ubx_modem);
+LOG_MODULE_DECLARE(ubx_modem, CONFIG_GNSS_UBX_MODEM_LOG_LEVEL);
 
 #ifndef CONFIG_GNSS_U_BLOX_NO_API_COMPAT
 


### PR DESCRIPTION
Add explicit log levels to the files using `LOG_MODULE_DECLARE`.