### PR TITLE
ci: workflows: self-hosted local pip cache

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -32,6 +32,7 @@ jobs:
       volumes:
         - /repo-cache/embeint:/github/cache/embeint
         - /repo-cache/ccache:/github/ccache
+        - /repo-cache/pip-cache:/github/pip-cache
     strategy:
       fail-fast: false
       matrix:
@@ -45,6 +46,7 @@ jobs:
             normalized: 'unit_testing'
 
     env:
+      PIP_CACHE_DIR: /github/pip-cache
       CCACHE_DIR: /github/ccache
       # `--specs` is ignored because ccache is unable to resolve the toolchain specs file path.
       CCACHE_IGNOREOPTIONS: '-specs=* --specs=*'
@@ -83,13 +85,11 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.12
-          cache: pip
-          cache-dependency-path: infuse-sdk/scripts/requirements-actions.txt
 
       - name: Install Python packages
         working-directory: infuse-sdk
         run: |
-          pip install -r scripts/requirements-actions.txt --require-hashes
+          pip install --cache-dir $PIP_CACHE_DIR -r scripts/requirements-actions.txt --require-hashes
 
       - name: Environment Setup
         working-directory: infuse-sdk
@@ -112,7 +112,7 @@ jobs:
       - name: Install Zephyr Python packages
         working-directory: zephyr
         run: |
-          pip install -r scripts/requirements.txt
+          pip install --cache-dir $PIP_CACHE_DIR -r scripts/requirements.txt
 
       - name: Check Environment
         run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -35,7 +35,9 @@ jobs:
       options: '--entrypoint /bin/bash'
       volumes:
       - /repo-cache/embeint:/github/cache/embeint
+      - /repo-cache/pip-cache:/github/pip-cache
       env:
+        PIP_CACHE_DIR: /github/pip-cache
         # NOTE: west docstrings will be extracted from the version listed here
         WEST_VERSION: 1.2.0
         # The latest CMake available directly with apt is 3.18, but we need >=3.20
@@ -75,13 +77,11 @@ jobs:
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: 3.12
-        cache: pip
-        cache-dependency-path: infuse-sdk/scripts/requirements-actions.txt
 
     - name: Install Python packages
       working-directory: infuse-sdk
       run: |
-        pip install -r scripts/requirements-actions.txt --require-hashes
+        pip install --cache-dir $PIP_CACHE_DIR -r scripts/requirements-actions.txt --require-hashes
 
     - name: Environment Setup
       working-directory: infuse-sdk
@@ -120,13 +120,11 @@ jobs:
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: 3.12
-        cache: pip
-        cache-dependency-path: zephyr/doc/requirements.txt
 
     - name: install-pip
       run: |
-        pip install -r zephyr/doc/requirements.txt --require-hashes
-        pip install -r infuse-sdk/doc/requirements.txt
+        pip install  --cache-dir $PIP_CACHE_DIR -r zephyr/doc/requirements.txt --require-hashes
+        pip install  --cache-dir $PIP_CACHE_DIR -r infuse-sdk/doc/requirements.txt
 
     - name: build-docs
       working-directory: infuse-sdk

--- a/.github/workflows/twister.yml
+++ b/.github/workflows/twister.yml
@@ -27,11 +27,13 @@ jobs:
       volumes:
         - /repo-cache/embeint:/github/cache/embeint
         - /repo-cache/ccache:/github/ccache
+        - /repo-cache/pip-cache:/github/pip-cache
     strategy:
       fail-fast: false
       matrix:
         subset: [1, 2, 3, 4]
     env:
+      PIP_CACHE_DIR: /github/pip-cache
       CCACHE_DIR: /github/ccache
       # `--specs` is ignored because ccache is unable to resolve the toolchain specs file path.
       CCACHE_IGNOREOPTIONS: '-specs=* --specs=*'
@@ -71,14 +73,12 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.12
-          cache: pip
-          cache-dependency-path: infuse-sdk/scripts/requirements-actions.txt
 
       - name: install-packages
         working-directory: infuse-sdk
         if: github.event_name == 'pull_request'
         run: |
-          pip install -r scripts/requirements-actions.txt --require-hashes
+          pip install --cache-dir $PIP_CACHE_DIR -r scripts/requirements-actions.txt --require-hashes
 
       - name: Environment Setup
         working-directory: infuse-sdk
@@ -102,7 +102,7 @@ jobs:
       - name: Install Zephyr Python packages
         working-directory: zephyr
         run: |
-          pip install -r scripts/requirements.txt
+          pip install --cache-dir $PIP_CACHE_DIR -r scripts/requirements.txt
 
       - name: Check Environment
         run: |

--- a/.github/workflows/west.yml
+++ b/.github/workflows/west.yml
@@ -24,7 +24,9 @@ jobs:
       options: '--entrypoint /bin/bash'
       volumes:
         - /repo-cache/embeint:/github/cache/embeint
+        - /repo-cache/pip-cache:/github/pip-cache
     env:
+      PIP_CACHE_DIR: /github/pip-cache
       BASE_REF: ${{ github.base_ref }}
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
     steps:
@@ -52,13 +54,11 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: infuse-sdk/scripts/requirements-actions.txt
 
       - name: Install Python packages
         working-directory: infuse-sdk
         run: |
-          pip install -r scripts/requirements-actions.txt --require-hashes
+          pip install  --cache-dir $PIP_CACHE_DIR -r scripts/requirements-actions.txt --require-hashes
 
       - name: Environment Setup
         working-directory: infuse-sdk
@@ -76,7 +76,7 @@ jobs:
           west update --path-cache /github/cache/embeint 2>&1 1> west.update.log || west update --path-cache /github/cache/embeint 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /github/cache/embeint)
           west forall -c 'git reset --hard HEAD'
 
-          pip install -r scripts/requirements.txt
+          pip install --cache-dir $PIP_CACHE_DIR -r scripts/requirements.txt
 
           echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-$( cat SDK_VERSION )" >> $GITHUB_ENV
 


### PR DESCRIPTION
Switch self-hosted jobs to use a local pip cache, instead of the github actions cache (which must be downloaded on each run).