### PR TITLE
bluetooth: custom assertion handling

### DIFF
--- a/include/infuse/lib/memfault_config/memfault_trace_reason_user_config.def
+++ b/include/infuse/lib/memfault_config/memfault_trace_reason_user_config.def
@@ -1,2 +1,3 @@
 /* Infuse-IoT specific Memfault traces */
 MEMFAULT_TRACE_REASON_DEFINE(secure_fault)
+MEMFAULT_TRACE_REASON_DEFINE(bt_ctlr_fault)

--- a/include/infuse/reboot.h
+++ b/include/infuse/reboot.h
@@ -54,6 +54,8 @@ enum infuse_reboot_reason {
 	INFUSE_REBOOT_SW_WATCHDOG = 134,
 	/** Rebooting for device firmware update */
 	INFUSE_REBOOT_DFU = 135,
+	/** Bluetooth controller fault */
+	INFUSE_REBOOT_BT_CTLR_FAULT = 136,
 	/** Unknown reboot reason */
 	INFUSE_REBOOT_UNKNOWN = 255,
 } __packed;

--- a/subsys/bluetooth/CMakeLists.txt
+++ b/subsys/bluetooth/CMakeLists.txt
@@ -6,3 +6,4 @@ if(CONFIG_BT_HCI_HOST)
 endif()
 
 zephyr_sources_ifdef(CONFIG_BT_CONTROLLER_MANAGER controller_manager.c)
+zephyr_sources_ifdef(CONFIG_BT_INFUSE_ASSERT_HANDLER assert_handler.c)

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -19,6 +19,13 @@ config BT_CONN_AUTO_RSSI
 	depends on BT_CTLR_CONN_RSSI || !HAS_BT_CTLR
 	default y
 
+config BT_INFUSE_ASSERT_HANDLER
+	bool "Handle Bluetooth controller assertions"
+	depends on INFUSE_REBOOT
+	depends on HAS_BT_CTLR
+	select BT_CTLR_ASSERT_HANDLER
+	default y
+
 if BT_CONN_AUTO_RSSI
 
 config BT_CONN_AUTO_RSSI_INTERVAL_MS

--- a/subsys/bluetooth/assert_handler.c
+++ b/subsys/bluetooth/assert_handler.c
@@ -1,0 +1,28 @@
+/**
+ * @file
+ * @copyright 2025 Embeint Holdings Pty Ltd
+ * @author Jordan Yates <jordan@embeint.com>
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+#include <zephyr/kernel.h>
+
+#include <infuse/reboot.h>
+
+#ifdef CONFIG_MEMFAULT
+#include <memfault/core/trace_event.h>
+#endif /* CONFIG_MEMFAULT */
+
+void bt_ctlr_assert_handle(char *file, uint32_t line)
+{
+#ifdef CONFIG_MEMFAULT
+	/* Store the assert information with Memfault if enabled */
+	MEMFAULT_TRACE_EVENT_WITH_LOG(bt_ctlr_fault, "%s:%u", file, line);
+	/* Trigger a fault so we get a backtrace */
+	k_oops();
+#else
+	/* Trigger a reboot */
+	infuse_reboot(INFUSE_REBOOT_BT_CTLR_FAULT, (uintptr_t)file, line);
+#endif /* CONFIG_MEMFAULT */
+}


### PR DESCRIPTION
Add custom handling for Bluetooth controller assertions to enable improved tracing and logging.