### PR TITLE
include: add missing `__packed` attributes

### DIFF
--- a/include/infuse/algorithm_runner/runner.h
+++ b/include/infuse/algorithm_runner/runner.h
@@ -39,7 +39,7 @@ struct algorithm_runner_common_config {
 		uint8_t loggers;
 		/** TDFs to log (bitmask defined by the activity) */
 		uint8_t tdf_mask;
-	} logging;
+	} __packed logging;
 } __packed;
 
 /**

--- a/include/infuse/reboot.h
+++ b/include/infuse/reboot.h
@@ -84,14 +84,14 @@ union infuse_reboot_info {
 		uint32_t info1;
 		/** Info 2 */
 		uint32_t info2;
-	} generic;
+	} __packed generic;
 	/* Basic exception information */
 	struct {
 		/** Program counter value at exception */
 		uint32_t program_counter;
 		/** Link register value at exception */
 		uint32_t link_register;
-	} exception_basic;
+	} __packed exception_basic;
 	/* Exception stack frame */
 	struct arch_esf exception_full;
 	/* Watchdog reboot information */
@@ -100,7 +100,7 @@ union infuse_reboot_info {
 		uint32_t info1;
 		/** Watchdog info2 per @ref infuse_watchdog_thread_state_lookup */
 		uint32_t info2;
-	} watchdog;
+	} __packed watchdog;
 } __packed __aligned(16);
 
 /** Reboot state information */

--- a/include/infuse/rpc/commands/security_state.h
+++ b/include/infuse/rpc/commands/security_state.h
@@ -34,7 +34,7 @@ struct security_state_response_hw_id_encrypted {
 	struct {
 		struct security_state_response_hw_id data;
 		uint8_t tag[16];
-	} ciphertext;
+	} __packed ciphertext;
 } __packed;
 
 #ifdef __cplusplus

--- a/include/infuse/task_runner/schedule.h
+++ b/include/infuse/task_runner/schedule.h
@@ -138,7 +138,7 @@ struct task_schedule_state_conditions {
 	uint8_t metadata;
 	/** Array of states to test */
 	uint8_t states[4];
-};
+} __packed;
 
 /**
  * Normally the lockout period must elapse after boot before the periodicity check passes.
@@ -168,26 +168,26 @@ struct task_schedule {
 		uint8_t lower;
 		/** Start task if <= this charge */
 		uint8_t upper;
-	} battery_start;
+	} __packed battery_start;
 	/** Battery charge thresholds to terminate the task */
 	struct battery_terminate_thresholds {
 		/** Terminate task if <= this charge */
 		uint8_t lower;
 		/** Terminate task if >= this charge */
 		uint8_t upper;
-	} battery_terminate;
+	} __packed battery_terminate;
 	/** Periodicity parameters */
 	union periodicity_args {
 		struct periodicity_periodic {
 			uint32_t period_s;
-		} fixed;
+		} __packed fixed;
 		struct periodicity_lockout {
 			uint32_t lockout_s;
-		} lockout;
+		} __packed lockout;
 		struct periodicity_after {
 			uint8_t schedule_idx;
 			uint16_t duration_s;
-		} after;
+		} __packed after;
 	} periodicity;
 	/** @a states_start will evaluate as true 2x this many seconds after last run started */
 	uint16_t states_start_timeout_2x_s;

--- a/include/infuse/task_runner/tasks/imu_args.h
+++ b/include/infuse/task_runner/tasks/imu_args.h
@@ -34,17 +34,20 @@ struct task_imu_args {
 	struct {
 		uint16_t rate_hz;
 		uint8_t range_g;
-	} accelerometer;
+		uint8_t pad;
+	} __packed accelerometer;
 	/** Gyroscope configuration  */
 	struct {
 		uint16_t rate_hz;
 		uint16_t range_dps;
-	} gyroscope;
+		uint8_t pad;
+	} __packed gyroscope;
 	/** Magnetometer configuration  */
 	struct {
 		uint16_t rate_hz;
 		uint8_t range_gauss;
-	} magnetometer;
+		uint8_t pad;
+	} __packed magnetometer;
 	/** Requested number of samples to buffer in FIFO */
 	uint16_t fifo_sample_buffer;
 	/** Run for this many buffers then terminate */

--- a/include/infuse/task_runner/tasks/network_scan_args.h
+++ b/include/infuse/task_runner/tasks/network_scan_args.h
@@ -70,7 +70,7 @@ struct task_network_scan_args {
 		uint8_t desired_aps;
 		/** Maximum number of access-points to report */
 		uint8_t max_aps;
-	} wifi;
+	} __packed wifi;
 	/** LTE Cell scanning arguments */
 	struct {
 		/**
@@ -80,7 +80,7 @@ struct task_network_scan_args {
 		 * cells.
 		 */
 		uint8_t desired_cells;
-	} lte;
+	} __packed lte;
 
 } __packed;
 


### PR DESCRIPTION
Add missing `__packed` attributes to nested structures. Add padding bytes to `struct task_imu_args` to keep memory layout for existing devices.