### PR TITLE
manifest: update zephyr fork

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -37,7 +37,7 @@ manifest:
           - zcbor
     - name: sdk-nrf
       path: modules/nrfconnect/sdk-nrf
-      revision: 2b555c2804b7cc745dccafc7aea6d1fefee0a42a
+      revision: 7c17ceccaf289dd33fe6453f44820b7bcaab5781
       import: true
     - name: memfault-firmware-sdk
       path: modules/lib/memfault


### PR DESCRIPTION
Update zephyr fork to fix small `k_malloc` allocations failing when only a single small `config HEAP_MEM_POOL_ADD_SIZE_{X}` symbol is defined.