### PR TITLE
validation: wifi: report `PASS` on success

### DIFF
--- a/subsys/validation/validation_wifi.c
+++ b/subsys/validation/validation_wifi.c
@@ -261,10 +261,12 @@ int infuse_validation_wifi(struct net_if *iface, uint8_t flags)
 	}
 
 done:
-
 	/* Put interface down if we brought it up */
 	if (manual_up) {
 		(void)net_if_down(iface);
+	}
+	if (rc == 0) {
+		VALIDATION_REPORT_PASS(TEST, "PASSED");
 	}
 	return rc;
 }


### PR DESCRIPTION
Add a missing `PASS` report if the test succeeded.