### PR TITLE
scripts: west_commands: cloudgen: explicit VLA handling

### DIFF
--- a/generated/include/infuse/fs/kv_types.h
+++ b/generated/include/infuse/fs/kv_types.h
@@ -366,8 +366,9 @@ struct kv_gravity_reference {
 
 /** Array of points defining a closed polygon */
 struct kv_geofence {
-	/** Points in geofence */
+	/** Number of points in the geofence */
 	uint8_t points_num;
+	/** Points in geofence */
 	struct gcs_location points[];
 } __packed;
 
@@ -425,6 +426,7 @@ struct kv_task_schedules {
 struct kv_secure_storage_reserved {
 	/** Opaque data */
 	uint8_t data_num;
+	/** Opaque data */
 	uint8_t data[];
 } __packed;
 

--- a/scripts/west_commands/cloud_definitions/kv_store.json
+++ b/scripts/west_commands/cloud_definitions/kv_store.json
@@ -18,6 +18,7 @@
         "kv_string": {
             "description": "String type",
             "fields": [
+                {"name": "value_num", "type": "uint8_t", "description": "Length of `value` (including NULL)"},
                 {"name": "value", "type": "char", "num": 0, "description": "NULL terminated C string"}
             ]
         },
@@ -312,6 +313,7 @@
             "description": "Array of points defining a closed polygon",
             "reflect": true,
             "fields": [
+                {"name": "points_num", "type": "uint8_t", "description": "Number of points in the geofence"},
                 {"name": "points", "type": "struct gcs_location", "num": 0, "description": "Points in geofence"}
             ]
         },
@@ -348,6 +350,7 @@
             "description": "Keys reserved for secure storage (do not enable)",
             "depends_on": "!INFUSE_SDK",
             "fields": [
+                {"name": "data_num", "type": "uint8_t", "description": "Opaque data"},
                 {"name": "data", "type": "uint8_t", "num": 0, "description": "Opaque data"}
             ]
         }

--- a/scripts/west_commands/templates/kv_types.h.jinja
+++ b/scripts/west_commands/templates/kv_types.h.jinja
@@ -31,11 +31,6 @@ extern "C" {
 /** {{ info['description'] }} */
 struct {{ name }} {
 {% for field in info['fields'] %}
-{% if field['num'] == 0 %}
-{% if info['fields']|length == 1 %}
-	uint8_t {{ field['name'] }}_num;
-{% endif %}
-{% endif %}
 	{{ field['type'] }} {{ field['name'] }}{{ field['array'] }};
 {% endfor %}
 } __packed;
@@ -47,9 +42,6 @@ struct {{ name }} {
 	struct { \
 	{% for field in info['fields'] %}
 	{% if field['num'] == 0 %}
-	{% if info['fields']|length == 1 %}
-		uint8_t {{ field['name'] }}_num; \
-	{% endif %}
 		{{ field['type'] }} {{ field['name'] }}[num]; \
 	{% else %}
 		{{ field['type'] }} {{ field['name'] }}{{ field['array'] }}; \


### PR DESCRIPTION
For the KV store, make the VLA requirements explicit, instead of automatically adding a non-VLA field in the template.