### PR TITLE
drivers: imu: data_types: remove `imu_sample` `__packed`

### DIFF
--- a/include/infuse/drivers/imu/data_types.h
+++ b/include/infuse/drivers/imu/data_types.h
@@ -24,11 +24,15 @@ extern "C" {
  * @{
  */
 
+/** IMU sample struct */
 struct imu_sample {
 	int16_t x;
 	int16_t y;
 	int16_t z;
-} __packed;
+};
+/* Validate __packed attribute is not required */
+BUILD_ASSERT(sizeof(struct imu_sample) == 6);
+BUILD_ASSERT(_Alignof(struct imu_sample) == 2);
 
 /** Metadata for each sub-sensor in a FIFO buffer */
 struct imu_sensor_meta {


### PR DESCRIPTION
One side effect of the `__packed` attribute is that the struct alignment is set to 1, which forces users to handle unaligned `int16_t`'s. Since we know there is no padding inserted, just validate the compiler isn't doing anything silly.

This should allow more efficient code generation in the IMU drivers and data consumers.