### PR TITLE
task_runner: tasks: gnss_ubx: fix net_buf size

### DIFF
--- a/subsys/task_runner/tasks/task_gnss_ubx.c
+++ b/subsys/task_runner/tasks/task_gnss_ubx.c
@@ -383,7 +383,7 @@ void gnss_task_fn(const struct task_schedule *schedule, struct k_poll_signal *te
 	}
 
 #ifdef CONFIG_GNSS_UBX_M10
-	NET_BUF_SIMPLE_DEFINE(cfg_buf, 48);
+	NET_BUF_SIMPLE_DEFINE(cfg_buf, 50);
 	ubx_msg_prepare_valset(&cfg_buf,
 			       UBX_MSG_CFG_VALSET_LAYERS_RAM | UBX_MSG_CFG_VALSET_LAYERS_BBR);
 	/* Core location message */


### PR DESCRIPTION
Configuration buffer was insufficiently sized when `CONFIG_TASK_RUNNER_GNSS_SATELLITE_INFO` is enabled and low power tracking is requested.