### PR TITLE
task: bt_scanner: logging scan results

### DIFF
--- a/subsys/task_runner/tasks/task_bt_scanner.c
+++ b/subsys/task_runner/tasks/task_bt_scanner.c
@@ -91,7 +91,7 @@ void task_bt_scanner_fn(struct k_work *work)
 	int rc;
 
 	if (task->executor.workqueue.reschedule_counter > 0) {
-		LOG_DBG("Terminating receive");
+		LOG_INF("Terminating receive (%u/%u)", state.num_observed, state.max_observed);
 		if ((args->flags & TASK_BT_SCANNER_FLAGS_DEFER_LOGGING) && state.num_observed) {
 			task_schedule_tdf_log_array(state.schedule, TASK_BT_SCANNER_LOG_INFUSE_BT,
 						    TDF_INFUSE_BLUETOOTH_RSSI,


### PR DESCRIPTION
Upon termination of the scan, include the number of observations and limit. This provides better visibility into the scan results.