### PR TITLE
sysbuild: fix `SB_CONFIG_INFUSE_INTEGRATION` detection

### DIFF
--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -1,12 +1,12 @@
 # Infuse-IoT sysbuild integration
 
-if(NOT ${SB_CONFIG_INFUSE_INTEGRATION})
+if(NOT SB_CONFIG_INFUSE_INTEGRATION)
   # Not Infuse sysbuild, exit
   return()
 endif()
 
-if(${SB_CONFIG_BOOTLOADER_MCUBOOT})
-  if(${SB_CONFIG_INFUSE_INTEGRATION_BT_CTLR})
+if(SB_CONFIG_BOOTLOADER_MCUBOOT)
+  if(SB_CONFIG_INFUSE_INTEGRATION_BT_CTLR)
     # infuse-bt-btlr snippet should be applied to MCUBoot application
     set(mcuboot_SNIPPET "infuse-bt-ctlr" CACHE INTERNAL "")
   else()


### PR DESCRIPTION
Fix the detection of whether the Infuse sysbuild integration should run.