### PR TITLE
net: conn_mgr: wifi_kv_store: clear cache on timeout

### DIFF
--- a/subsys/net/conn_mgr/conn_mgr_wifi_kv_store.c
+++ b/subsys/net/conn_mgr/conn_mgr_wifi_kv_store.c
@@ -173,6 +173,10 @@ static void conn_timeout_worker(struct k_work *work)
 	manual_disconnect = true;
 	LOG_INF("Connection attempt timed out");
 
+	/* Reset cached band & channel information */
+	last_band = WIFI_FREQ_BAND_UNKNOWN;
+	last_channel = UINT_MAX;
+
 	/* Cancel any pending connections */
 	k_work_cancel_delayable(&conn_create);
 	(void)net_mgmt(NET_REQUEST_WIFI_DISCONNECT, wifi_if, NULL, 0);


### PR DESCRIPTION
Reset any cached band and channel information when a connection times out. This fixes the manager continuously failing to connect to a network when it switches to a different frequency.