### PR TITLE
apps: gateway_lte: improve LEDs and robustness

### DIFF
--- a/apps/gateway_lte/src/main.c
+++ b/apps/gateway_lte/src/main.c
@@ -339,12 +339,14 @@ int main(void)
 
 #ifdef CONFIG_MODEM_CELLULAR
 	/* For now the Cellular Modem abstraction is not linked to a connection manager */
-	pm_device_runtime_get(DEVICE_DT_GET(DT_ALIAS(modem)));
-#endif /* CONFIG_MODEM_CELLULAR */
+	struct net_if *iface = net_if_get_first_by_type(&(NET_L2_GET_NAME(PPP)));
 
+	net_if_up(iface);
+#else
 	/* Turn on the interface */
 	conn_mgr_all_if_up(true);
 	conn_mgr_all_if_connect(true);
+#endif /* CONFIG_MODEM_CELLULAR */
 
 	/* Initialise task runner */
 	task_runner_init(schedules, states, ARRAY_SIZE(schedules), app_tasks, app_tasks_data,

--- a/apps/gateway_lte/src/main.c
+++ b/apps/gateway_lte/src/main.c
@@ -148,9 +148,9 @@ TASK_RUNNER_TASKS_DEFINE(app_tasks, app_tasks_data, (TDF_LOGGER_TASK, custom_tdf
 
 GATEWAY_HANDLER_DEFINE(udp_backhaul_handler, DEVICE_DT_GET(DT_NODELABEL(epacket_udp)));
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_ALIAS(led0))
-static const struct gpio_dt_spec led0 = GPIO_DT_SPEC_GET(DT_ALIAS(led0), gpios);
-#endif
+static const struct gpio_dt_spec led0 = GPIO_DT_SPEC_GET_OR(DT_ALIAS(led0), gpios, {0});
+static const struct gpio_dt_spec led1 = GPIO_DT_SPEC_GET_OR(DT_ALIAS(led1), gpios, {0});
+static const struct gpio_dt_spec led2 = GPIO_DT_SPEC_GET_OR(DT_ALIAS(led2), gpios, {0});
 
 /* Forward 25% of all Bluetooth packets by default, RSSI if whole packet dropped */
 static const struct kv_gateway_bluetooth_forward_options bt_forwarding_options_default = {
@@ -257,8 +257,46 @@ static void bluetooth_adv_handler(struct net_buf *buf)
 	}
 }
 
+static void leds_init(void)
+{
+	if (led0.port) {
+		(void)gpio_pin_configure_dt(&led0, GPIO_OUTPUT_INACTIVE);
+	}
+	if (led1.port) {
+		(void)gpio_pin_configure_dt(&led1, GPIO_OUTPUT_INACTIVE);
+	}
+	if (led2.port) {
+		(void)gpio_pin_configure_dt(&led2, GPIO_OUTPUT_INACTIVE);
+	}
+}
+
+static void led_set_dt(const struct gpio_dt_spec *spec, int value)
+{
+	if (spec->port == NULL) {
+		return;
+	}
+	gpio_pin_set_dt(spec, value);
+}
+
+static void led_pulse_dt(const struct gpio_dt_spec *spec, k_timeout_t pulse_duration)
+{
+	if (spec->port == NULL) {
+		return;
+	}
+	gpio_pin_set_dt(spec, 1);
+	k_sleep(pulse_duration);
+	gpio_pin_set_dt(spec, 0);
+}
+
 int main(void)
 {
+#if defined(CONFIG_NRF_MODEM_LIB)
+	struct net_if *iface = net_if_get_first_by_type(&(NET_L2_GET_NAME(OFFLOADED_NETDEV)));
+#elif defined(CONFIG_NET_L2_PPP)
+	struct net_if *iface = net_if_get_first_by_type(&(NET_L2_GET_NAME(PPP)));
+#else
+#error Unknown LTE modem network interface
+#endif
 	const struct device *bt_adv = DEVICE_DT_GET(DT_NODELABEL(epacket_bt_adv));
 	const struct device *bt_central = DEVICE_DT_GET(DT_NODELABEL(epacket_bt_central));
 	const struct device *udp = DEVICE_DT_GET(DT_NODELABEL(epacket_udp));
@@ -272,6 +310,7 @@ int main(void)
 	struct kv_store_cb kv_cb = {
 		.value_changed = kv_value_changed,
 	};
+	uint16_t udp_payload_size;
 	int rc;
 
 #if CONFIG_LTE_GATEWAY_DEFAULT_MAXIMUM_UPLINK_THROUGHPUT_KBPS > 0
@@ -295,6 +334,9 @@ int main(void)
 		memcpy(&bt_forwarding_options, &bt_forwarding_options_default,
 		       sizeof(bt_forwarding_options));
 	}
+
+	/* Set up LEDs */
+	leds_init();
 
 	/* KV store callbacks */
 	kv_store_register_callback(&kv_cb);
@@ -339,8 +381,6 @@ int main(void)
 
 #ifdef CONFIG_MODEM_CELLULAR
 	/* For now the Cellular Modem abstraction is not linked to a connection manager */
-	struct net_if *iface = net_if_get_first_by_type(&(NET_L2_GET_NAME(PPP)));
-
 	net_if_up(iface);
 #else
 	/* Turn on the interface */
@@ -355,18 +395,29 @@ int main(void)
 	/* Start auto iteration */
 	task_runner_start_auto_iterate();
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_ALIAS(led0))
-	(void)gpio_pin_configure_dt(&led0, GPIO_OUTPUT_INACTIVE);
-
 	/* Boot LED sequence */
 	for (int i = 0; i < 5; i++) {
-		(void)gpio_pin_toggle_dt(&led0);
+		led_set_dt(&led0, 1);
+		led_set_dt(&led1, 1);
+		led_set_dt(&led2, 1);
+		k_sleep(K_MSEC(200));
+		led_set_dt(&led0, 0);
+		led_set_dt(&led1, 0);
+		led_set_dt(&led2, 0);
 		k_sleep(K_MSEC(200));
 	}
-	gpio_pin_set_dt(&led0, 0);
-#endif /* DT_NODE_HAS_STATUS_OKAY(DT_ALIAS(led0)) */
 
-	/* Nothing further to do */
-	k_sleep(K_FOREVER);
-	return 0;
+	/* Periodic LEDs based on connection state */
+	while (true) {
+		k_sleep(K_SECONDS(5));
+
+		udp_payload_size = epacket_interface_max_packet_size(udp);
+		if (!net_if_flag_is_set(iface, NET_IF_LOWER_UP)) {
+			led_pulse_dt(&led0, K_SECONDS(1));
+		} else if (udp_payload_size > 0) {
+			led_pulse_dt(&led1, K_MSEC(200));
+		} else {
+			led_pulse_dt(&led2, K_MSEC(200));
+		}
+	}
 }

--- a/lib/modem_monitor/modem_cellular/cellular_modem_monitor.c
+++ b/lib/modem_monitor/modem_cellular/cellular_modem_monitor.c
@@ -112,8 +112,20 @@ static void modem_info_changed(const struct device *dev, const struct cellular_e
 static void registration_status_changed(const struct device *dev,
 					const struct cellular_evt_registration_status *rs)
 {
+	/* Callback does not mean that status has necessarily changed (unsolicited CxREG) */
+	if (rs->status == monitor.network_state.nw_reg_status) {
+		return;
+	}
+
 	LOG_DBG("Registration status: %d", rs->status);
 	monitor.network_state.nw_reg_status = rs->status;
+
+	if ((rs->status == CELLULAR_REGISTRATION_REGISTERED_HOME) ||
+	    (rs->status == CELLULAR_REGISTRATION_REGISTERED_ROAMING)) {
+		modem_monitor_ip_connectivity_expected(true);
+	} else {
+		modem_monitor_ip_connectivity_expected(false);
+	}
 }
 
 static void network_status_changed(const struct device *dev,

--- a/lib/modem_monitor/modem_cellular/cellular_modem_monitor.c
+++ b/lib/modem_monitor/modem_cellular/cellular_modem_monitor.c
@@ -12,7 +12,6 @@
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/toolchain.h>
-#include <zephyr/pm/device_runtime.h>
 
 #include <infuse/lib/lte_modem_monitor.h>
 #include <infuse/fs/kv_store.h>
@@ -146,6 +145,7 @@ static void network_status_changed(const struct device *dev,
 static void comms_check_result(const struct device *dev,
 			       const struct cellular_evt_modem_comms_check_result *ccr)
 {
+	struct net_if *iface = net_if_get_first_by_type(&(NET_L2_GET_NAME(PPP)));
 	static uint8_t consecutive_failures;
 
 	if (ccr->success) {
@@ -160,7 +160,7 @@ static void comms_check_result(const struct device *dev,
 	LOG_WRN("Modem AT link dead, suspending %s", dev->name);
 	/* Suspend the modem */
 	monitor.at_link_dead = true;
-	pm_device_runtime_put(dev);
+	net_if_down(iface);
 }
 
 static void modem_suspended(const struct device *dev)

--- a/lib/modem_monitor/modem_monitor.c
+++ b/lib/modem_monitor/modem_monitor.c
@@ -34,6 +34,7 @@ static void connectivity_timeout(struct k_work *work)
 {
 	if (!atomic_test_bit(&generic_monitor.flags, FLAGS_IP_CONN_EXPECTED)) {
 		/* Network registration was lost before interface state callback occurred */
+		LOG_DBG("Timeout expired but connectivity not expected");
 		return;
 	}
 
@@ -55,9 +56,11 @@ static void iface_state_handler(struct net_mgmt_event_callback *cb, uint64_t mgm
 	}
 	if (mgmt_event == NET_EVENT_IF_UP) {
 		/* Interface is UP, cancel the timeout */
+		LOG_DBG("Interface %p is UP, cancelling timeout", iface);
 		k_work_cancel_delayable(&generic_monitor.connectivity_timeout);
 	} else if (mgmt_event == NET_EVENT_IF_DOWN) {
 		/* Interface is DOWN, restart the timeout */
+		LOG_DBG("Interface %p is DOWN, cancelling timeout", iface);
 		k_work_reschedule(&generic_monitor.connectivity_timeout, CONNECTIVITY_TIMEOUT);
 	}
 }
@@ -65,9 +68,11 @@ static void iface_state_handler(struct net_mgmt_event_callback *cb, uint64_t mgm
 void modem_monitor_ip_connectivity_expected(bool expected)
 {
 	if (expected) {
+		LOG_DBG("IP connectivity expected");
 		atomic_set_bit(&generic_monitor.flags, FLAGS_IP_CONN_EXPECTED);
 		k_work_reschedule(&generic_monitor.connectivity_timeout, CONNECTIVITY_TIMEOUT);
 	} else {
+		LOG_DBG("IP connectivity not expected");
 		atomic_clear_bit(&generic_monitor.flags, FLAGS_IP_CONN_EXPECTED);
 		k_work_cancel_delayable(&generic_monitor.connectivity_timeout);
 	}

--- a/lib/modem_monitor/modem_monitor.c
+++ b/lib/modem_monitor/modem_monitor.c
@@ -48,19 +48,19 @@ static void connectivity_timeout(struct k_work *work)
 #endif /* CONFIG_INFUSE_REBOOT */
 }
 
-static void iface_state_handler(struct net_mgmt_event_callback *cb, uint64_t mgmt_event,
-				struct net_if *iface)
+static void l4_event_handler(struct net_mgmt_event_callback *cb, uint64_t mgmt_event,
+			     struct net_if *iface)
 {
 	if (iface != generic_monitor.net_if) {
 		return;
 	}
-	if (mgmt_event == NET_EVENT_IF_UP) {
-		/* Interface is UP, cancel the timeout */
-		LOG_DBG("Interface %p is UP, cancelling timeout", iface);
+	if (mgmt_event == NET_EVENT_L4_CONNECTED) {
+		/* Interface is connected, cancel the timeout */
+		LOG_DBG("Interface %p is connected, cancelling timeout", iface);
 		k_work_cancel_delayable(&generic_monitor.connectivity_timeout);
-	} else if (mgmt_event == NET_EVENT_IF_DOWN) {
-		/* Interface is DOWN, restart the timeout */
-		LOG_DBG("Interface %p is DOWN, cancelling timeout", iface);
+	} else if (mgmt_event == NET_EVENT_L4_DISCONNECTED) {
+		/* Interface is disconnected, restart the timeout */
+		LOG_DBG("Interface %p is disconnected, restarting timeout", iface);
 		k_work_reschedule(&generic_monitor.connectivity_timeout, CONNECTIVITY_TIMEOUT);
 	}
 }
@@ -83,7 +83,7 @@ void modem_monitor_init(struct net_if *iface)
 	__ASSERT_NO_MSG(iface != NULL);
 	generic_monitor.net_if = iface;
 	k_work_init_delayable(&generic_monitor.connectivity_timeout, connectivity_timeout);
-	net_mgmt_init_event_callback(&generic_monitor.mgmt_iface_cb, iface_state_handler,
-				     NET_EVENT_IF_UP | NET_EVENT_IF_DOWN);
+	net_mgmt_init_event_callback(&generic_monitor.mgmt_iface_cb, l4_event_handler,
+				     NET_EVENT_L4_CONNECTED | NET_EVENT_L4_DISCONNECTED);
 	net_mgmt_add_event_callback(&generic_monitor.mgmt_iface_cb);
 }

--- a/lib/reboot.c
+++ b/lib/reboot.c
@@ -65,17 +65,50 @@ static void reboot_state_store(enum infuse_reboot_reason reason,
 	retention_write(retention, 0, (void *)&state, sizeof(state));
 }
 
+#if defined(CONFIG_MODEM_CELLULAR)
+
+static bool networking_trigger_shutdown(void)
+{
+	/* For now the Cellular Modem abstraction is not linked to a connection manager */
+	struct net_if *iface = net_if_get_first_by_type(&(NET_L2_GET_NAME(PPP)));
+
+	return net_if_down(iface) == 0 ? true : false;
+}
+
+#elif defined(CONFIG_NET_CONNECTION_MANAGER)
+
+static bool networking_trigger_shutdown(void)
+{
+	(void)conn_mgr_all_if_disconnect(false);
+	(void)conn_mgr_all_if_down(false);
+	return true;
+}
+
+#else
+
+static bool networking_trigger_shutdown(void)
+{
+	/* No modem to shutdown */
+	return false;
+}
+
+#endif
+
+static bool networking_attempt_clean_shutdown(void)
+{
+	/* If not in an interrupt context, attempt to cleanly bring
+	 * down all networking interfaces when triggering a reboot.
+	 */
+	if (k_is_in_isr()) {
+		return false;
+	}
+
+	/* Trigger the networking interfaces to shutdown */
+	return networking_trigger_shutdown();
+}
+
 FUNC_NORETURN static void cleanup_and_reboot(void)
 {
-#ifdef CONFIG_NET_CONNECTION_MANAGER
-	if (!k_is_in_isr()) {
-		/* If not in an interrupt context, attempt to cleanly bring
-		 * down all networking interfaces before rebooting.
-		 */
-		(void)conn_mgr_all_if_disconnect(false);
-		(void)conn_mgr_all_if_down(false);
-	}
-#endif /* CONFIG_NET_CONNECTION_MANAGER*/
 	/* Flush any logs */
 	LOG_PANIC();
 	/* Trigger the reboot */
@@ -137,6 +170,11 @@ void infuse_watchdog_expired(const struct device *dev, int channel_id)
 
 FUNC_NORETURN void infuse_reboot(enum infuse_reboot_reason reason, uint32_t info1, uint32_t info2)
 {
+	/* Request networking backends to shutdown */
+	if (networking_attempt_clean_shutdown()) {
+		/* Some backend is shutting down, give it a chance to complete */
+		k_sleep(K_SECONDS(2));
+	}
 	/* Store reboot metadata */
 	reboot_state_store(reason, INFUSE_REBOOT_INFO_GENERIC, info1, info2, NULL);
 	/* Do the reboot */
@@ -152,6 +190,9 @@ void infuse_reboot_delayed(enum infuse_reboot_reason reason, uint32_t info1, uin
 	/* Set rebooting state */
 	infuse_state_set(INFUSE_STATE_REBOOTING);
 #endif
+
+	/* Request networking backends to shutdown while we're waiting to reboot */
+	networking_attempt_clean_shutdown();
 
 	/* Init the worker */
 	k_work_init_delayable(&reboot_worker, delayed_do_reboot);

--- a/tests/net/nrf_modem_lib/src/main.c
+++ b/tests/net/nrf_modem_lib/src/main.c
@@ -160,8 +160,10 @@ ZTEST(infuse_nrf_modem_monitor, test_integration)
 	struct net_if *iface = net_if_get_default();
 	struct lte_modem_network_state net_state;
 	struct nrf_modem_fault_info fault_info = {0};
+	char ipv4_addr[NET_IPV4_ADDR_LEN] = {0};
 	enum pdn_fam default_family;
 	const char *default_apn;
+	struct net_if_addr *added;
 	int rc;
 
 #ifdef CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG
@@ -340,6 +342,21 @@ ZTEST(infuse_nrf_modem_monitor, test_integration)
 	rc = net_if_up(iface);
 	zassert_equal(0, rc);
 
+	/* Connectivity timeout as we don't have IP connectivity */
+	rc = k_sem_take(&reboot_request,
+			K_SECONDS(CONFIG_INFUSE_MODEM_MONITOR_CONNECTIVITY_TIMEOUT_SEC + 1));
+	zassert_equal(0, rc);
+
+	/* Revert to searching */
+	nrf_modem_lib_sim_send_at("+CEREG: 2,\"702A\",\"08C3BD0C\",7\r\n");
+	k_sleep(K_SECONDS(1));
+
+	/* Back on the network, gain network and IP connectivity this time */
+	nrf_modem_lib_sim_send_at(
+		"+CEREG: 5,\"702A\",\"08C3BD0C\",7,,,\"00001000\",\"00101101\"\r\n");
+	added = net_if_ipv4_addr_add(iface, (struct in_addr *)&ipv4_addr, NET_ADDR_MANUAL, 0);
+	zassert_not_null(added);
+
 	/* No connectivity timeout */
 	rc = k_sem_take(&reboot_request,
 			K_SECONDS(CONFIG_INFUSE_MODEM_MONITOR_CONNECTIVITY_TIMEOUT_SEC + 1));
@@ -367,11 +384,12 @@ ZTEST(infuse_nrf_modem_monitor, test_integration)
 
 	/* Modem wakes */
 	nrf_modem_lib_sim_send_at("%XMODEMSLEEP: 1,0\r\n");
-	/* Network connectivity goes down, reboot should be requested */
-	rc = net_if_down(iface);
-	zassert_equal(0, rc);
+	/* IP connectivity goes down, reboot should be requested */
+	zassert_true(net_if_ipv4_addr_rm(iface, (struct in_addr *)&ipv4_addr));
 	rc = k_sem_take(&reboot_request,
 			K_SECONDS(CONFIG_INFUSE_MODEM_MONITOR_CONNECTIVITY_TIMEOUT_SEC + 1));
+	zassert_equal(0, rc);
+	rc = net_if_down(iface);
 	zassert_equal(0, rc);
 
 	/* Back to searching */

--- a/west.yml
+++ b/west.yml
@@ -14,7 +14,7 @@ manifest:
 
   projects:
     - name: zephyr
-      revision: a001baa1d5b8f5a70b3b7a02aac5330b6d350d2b
+      revision: 2f053d91267aa1c637e74202f17dd95393f5bc58
       # Limit imported repositories to reduce clone time
       import:
         name-allowlist:


### PR DESCRIPTION
 * apps: gateway_lte: improve LED indications
 * reboot: handle `modem_cellular` shutdown
 * apps: gateway_lte: use `net_if_up`
 * modem_monitor: use L4 connectivity events
 * modem_monitor: cellular: use the connectivity watcher