### PR TITLE
doc: getting started: update and fix docs

### DIFF
--- a/doc/getting_started/embedded/index.rst
+++ b/doc/getting_started/embedded/index.rst
@@ -29,38 +29,51 @@ in the `Zephyr Getting Started Guide <zephyr_started_>`_ for your respective OS.
 
 .. note::
 
+    When installing the Zephyr SDK, the installer will prompt you to install optional host tools and toolchains.
+    Different build targets will require different toolchains.
+    See: `Installing the correct Toolchains`_ for more details.
+
+.. note::
+
     When flashing the Blinky sample, you may need appropriate programmer tools for your microcontroller.
-    See the next step for more details.
+    See: `Install Programmer and Microcontroller specific tools`_ for more details.
 
 .. note::
 
     Developing on Windows has two options: Native development or WSL (Windows Subsystem for Linux).
-    Both options are valid for installation, however not all tools have been tested to work on Native Windows.
+    Both options are valid for installation, however not all tools have been tested to work natively on Windows.
 
     For more details using WSL see the :ref:`getting-started-embedded-wsl`.
 
+Installing the correct Toolchains
+---------------------------------
+
+While setting up Zephyr SDK, ensure to select the required toolchain(s) for your build targets.
+Below are a few relevant ones:
+
+    * ``arm-zephyr-eabi``: For ARM EABI targets such as Nordic nRF and STM32 boards (including QEMU targets).
+    * ``x86_64-zephyr-elf``: For x86 posix/native targets (Used for Babblesim, only valid on Linux).
+
+The SDK setup installer can be re-run to add additional toolchains at a later date if needed.
+
 Install Programmer and Microcontroller specific tools
-*****************************************************
+-----------------------------------------------------
 
 Install host tools required for your microcontroller and programmer (if you haven't already).
-Below is a list of the tools required for programmers for the microcontrollers supported by infuse:
+Below is a list of the tools required for programmers for the microcontrollers supported by Infuse-Iot:
 
-    * nRF: `nRF Command Line Tools <nrf_cli_tools_>`_
+    * Nordic: `nRF Util <nrf_util_>`_
     * STM32: `stm32cubeprog`_
+    * Nordic: `nRF Command Line Tools <nrf_cli_tools_>`_ (Deprecated)
 
-.. note::
-
-    nRF Command line tools comes bundled with the `Segger JLink Tools <https://www.segger.com/downloads/jlink/>_`.
-    Follow the appropriate prompts to install both.
-
-Ensure the blinky example flashes to the board before continuing.
+Ensure Zephyr's blinky example flashes to the board before continuing.
 
 Install Infuse-IoT Embedded SDK
 *******************************
 
 Now that you have Zephyr installed and working, you can setup Infuse-IoT's Embedded SDK. This
-will be setup as a standalone west workspace in ``~/infuse-iot``.
-(A different destination folder can be used at your own risk)
+will be setup as a separate, standalone west workspace in ``~/infuse``.
+A different destination folder can be used, but corresponding commands will need to be updated accordingly.
 
 Setup and Clone out the Infuse-IoT Embedded SDK using:
 
@@ -92,34 +105,6 @@ Setup and Clone out the Infuse-IoT Embedded SDK using:
                 west init -m git@github.com:Embeint/infuse-sdk.git
                 west update
 
-.. note::
-
-    Ensure you have access to `infuse_sdk`_ on GitHub and have added your
-    `SSH key <https://github.com/settings/keys>`_ to GitHub.
-
-    If the clone fails (e.g. due to permissions issues), the ``~/infuse-iot/.west``
-    folder will likely need to be deleted before trying reattempting. This can be done by running:
-
-    .. tabs::
-
-        .. group-tab:: bash/zsh
-
-            .. code:: bash
-
-                    rm -rf ~/infuse-iot/.west/
-
-        .. group-tab:: Windows (PowerShell)
-
-            .. code:: bash
-
-                    rm -r ~/infuse-iot/.west/
-
-        .. group-tab:: Windows (CMD)
-
-            .. code:: batch
-
-                    rd /s /q %USERPROFILE%\infuse-iot\.west\
-
 Finally install any Python requirements:
 
 .. tabs::
@@ -127,19 +112,19 @@ Finally install any Python requirements:
 
         .. code:: bash
 
-                pip install -U -r ~/infuse-iot/infuse-sdk/scripts/requirements.txt
+                pip install -U -r ~/infuse/infuse-sdk/scripts/requirements.txt
 
     .. group-tab:: Windows (PowerShell)
 
         .. code:: bash
 
-                pip install -U -r ~/infuse-iot/infuse-sdk/scripts/requirements.txt
+                pip install -U -r ~/infuse/infuse-sdk/scripts/requirements.txt
 
     .. group-tab:: Windows (CMD)
 
         .. code:: batch
 
-                pip install -U -r %USERPROFILE%\infuse-iot\infuse-sdk\scripts\requirements.txt
+                pip install -U -r %USERPROFILE%\infuse\infuse-sdk\scripts\requirements.txt
 
 Infuse-IoT should now be installed, next steps include building and flashing an application to
 verify everything is working.
@@ -159,30 +144,34 @@ This configures the build directory to be formatted as *build/name_of_board/name
 For example, building the ``gateway_usb`` application for the ``nrf52840dk`` outputs the
 build to ``build/nrf52840dk/nrf52840/gateway_usb``.
 
-By default, Zephyr attempts to overwrite the old build directory when switching between apps or boards.
-This feature is useful because when using this layout, switching between apps or boards no
-longer overwrites your existing build directory. When you switch back, the previous build
-is preserved and the entire app doesn’t need to be rebuilt from scratch.
+By default, Zephyr only keeps track of one project at a time. Switching project (by building a different
+app or board) requires users to overwrite the old build directory, causing the loss of previous build files.
+By configuring west to use this build directory format, each new project is stored in a separate folder.
+As a result, switching between apps or boards preserved previous builds and switching back no longer requires a
+full rebuild. This is recommended, but is optional and can be skipped if you prefer to use the default
+build directory behaviour.
 
-.. note::
+.. caution::
 
-    This is recommended, but is optional and can be skipped if you prefer to use the default
-    build directory.
+    Some ``west`` commands automatically detect the build directory. However, using this configuration
+    creates multiple build directories. As a result, commands that use the build directory will require
+    the build directory to be specified manually.
+    This can easily be done supplying the ``-d`` flag (``--build-dir``).
 
-.. note::
-
-    Some `west` commands automatically detect the build directory.
-    Using this configuration will require the build directly to be manually specified.
-    This can easily be done using the ``-d`` flag
-
-    e.g. ``west flash -d build/nrf52840dk/nrf52840/gateway_usb`` when run from ``~/infuse-iot``.
+    e.g. flashing a device would have previously just required ``west flash``, and will now require
+    ``west flash -d build/nrf52840dk/nrf52840/gateway_usb`` when run from ``~/infuse``.
 
 Build and Flash a Infuse App
 ****************************
 
 It's now time to build and flash an Infuse-IoT Application.
 
-For a Nordic nRF52840 Dev kit, you can build and flash the ``gateway_usb`` application.
+The ``gateway_usb`` application allows a Zephyr device to communicate with your host system (over serial) and by
+functioning as a bluetooth gateway, allows your machine to interact with nearby Infuse devices over Bluetooth. It can
+be run on boards with Bluetooth and Serial comms (USB or RTT), which covers many of Nordic's development boards.
+The example below uses the Nordic nRF52840 Dev kit (``nrf52840dk``) but similar boards can be used by switching out the
+board name with that of your desired board.
+To build the ``gateway_usb`` application for the ``nrf52840dk``, run the following command:
 
 .. code:: bash
 
@@ -190,7 +179,7 @@ For a Nordic nRF52840 Dev kit, you can build and flash the ``gateway_usb`` appli
 
 .. note::
 
-    Ensure you are in the ``~/infuse-iot`` directory.
+    Ensure that the current directory is ``~/infuse`` before running the build and subsequent commands.
 
 and flash it with
 
@@ -200,16 +189,19 @@ and flash it with
 
 .. note::
 
-    It may be helpful to setup the :ref:`tooling_python_tools` to interact with the ``gateway_usb``.
+    It may be helpful to setup the :ref:`tooling_python_tools` to interact with the ``gateway_usb`` to test it's working.
+    Otherwise if your board has LEDs, one should flash once a second, and additional serial ports should appear when
+    connecting the device to a computer.
 
-If the build and flash succeeded, Infuse-IoT Embedded SDK has been successfully installed. Check
-out how to setup `VScode` or other useful tips further below. If not check out the troubleshooting
+
+If the build and flash succeeded, Infuse-IoT Embedded SDK has been successfully installed.
+Check out how to setup Visual Studio Code or other useful tips further below. If not check out the troubleshooting
 section.
 
 Troubleshooting
 ***************
 
-- Ensure to build applications from inside ``~/infuse-iot`` and not from ``~/infuse-iot/infuse-sdk``, or other folders.
+- Ensure to build applications from inside ``~/infuse`` and not from ``~/infuse/infuse-sdk``, or other folders.
 - If ``west init`` or ``git clone`` fails, subsequent attempts may fail. Remove the ``.west`` or ``.git``
   directory respectively before retrying.
 
@@ -224,7 +216,7 @@ Troubleshooting
         permissions so it all needs to be done all over again. Thanks Apple.
 
 VSCode Setup
-*************
+************
 
 VS Code is the preferred development environment for Infuse-IoT. It has many integrations with Kconfig.
 
@@ -250,7 +242,7 @@ VS Code is the preferred development environment for Infuse-IoT. It has many int
         <https://code.visualstudio.com/download>`__.
 
 
-Once installed, open VSCode, select "Open Folder" and navigate to ``~/infuse-iot``.
+Once installed, open VSCode, select "Open Folder" and navigate to ``~/infuse``.
 
 Check out :ref:`tooling_vscode_integration` for more details and tips.
 
@@ -259,7 +251,7 @@ Useful Tips
 
 General Tips:
 
-- ``~/infuse-iot`` is like a workspace for Zephyr/Infuse-IoT. ``~/infuse-iot/infuse-sdk``
+- ``~/infuse`` is like a workspace for Zephyr/Infuse-IoT. ``~/infuse/infuse-sdk``
   contains the Infuse-IoT Embedded SDK.
 - The Zephyr installation at ``~/zephyrproject`` is no longer required for Infuse-IoT and can be removed if
   you don't need a mainline zephyr workspace.
@@ -269,7 +261,7 @@ General Tips:
         Zephyr installs the Python virtual environment under ``~/zephyrproject/zephyr/.venv``.
         Deleting ``~/zephyrproject``, will require re-creating the venv first.
         Do not attempt to move the ``.venv`` since this can lead to issues.
-        To recreate the venv to e.g. ``~/infuse-iot/.venv`` (with the ``zephyrproject/.venv`` already activated):
+        To recreate the venv to e.g. ``~/infuse/.venv`` (with the ``zephyrproject/.venv`` is activated):
 
         .. tabs::
 
@@ -277,31 +269,31 @@ General Tips:
 
                 .. code:: bash
 
-                        pip freeze > ~/infuse-iot/requirements.txt
-                        python3 -m venv ~/infuse-iot/.venv
-                        source ~/infuse-iot/.venv/bin/activate
-                        pip install -r ~/infuse-iot/requirements.txt
-                        rm ~/infuse-iot/requirements.txt
+                        pip freeze > ~/infuse/requirements.txt
+                        python3 -m venv ~/infuse/.venv
+                        source ~/infuse/.venv/bin/activate
+                        pip install -r ~/infuse/requirements.txt
+                        rm ~/infuse/requirements.txt
 
             .. group-tab:: Windows (PowerShell)
 
                 .. code:: bash
 
-                        pip freeze > ~/infuse-iot/requirements.txt
-                        python3 -m venv ~/infuse-iot/.venv
-                        source ~/infuse-iot/.venv/bin/activate
-                        pip install -r ~/infuse-iot/requirements.txt
-                        rm ~/infuse-iot/requirements.txt
+                        pip freeze > ~/infuse/requirements.txt
+                        python3 -m venv ~/infuse/.venv
+                        source ~/infuse/.venv/bin/activate
+                        pip install -r ~/infuse/requirements.txt
+                        rm ~/infuse/requirements.txt
 
             .. group-tab:: Windows (CMD)
 
                 .. code:: batch
 
-                        pip freeze > %USERPROFILE%\infuse-iot\requirements.txt
-                        python3 -m venv %USERPROFILE%\infuse-iot\.venv
-                        source %USERPROFILE%\infuse-iot\.venv\bin\activate
-                        pip install -r %USERPROFILE%/infuse-iot\requirements.txt
-                        rm %USERPROFILE%\infuse-iot\requirements.txt
+                        pip freeze > %USERPROFILE%\infuse\requirements.txt
+                        python3 -m venv %USERPROFILE%\infuse\.venv
+                        source %USERPROFILE%\infuse\.venv\bin\activate
+                        pip install -r %USERPROFILE%\infuse\requirements.txt
+                        rm %USERPROFILE%\infuse\requirements.txt
 
 .. _zephyr_started: https://docs.zephyrproject.org/latest/develop/getting_started/index.html
 .. _python: https://docs.zephyrproject.org/latest/develop/getting_started/index.html#get-zephyr-and-install-python-dependencies
@@ -309,4 +301,5 @@ General Tips:
 .. _zephyr_sdk: https://docs.zephyrproject.org/latest/develop/toolchains/zephyr_sdk.html#toolchain-zephyr-sdk-install
 .. _zephyr_sdk_releases: https://github.com/zephyrproject-rtos/sdk-ng/releases
 .. _nrf_cli_tools: https://www.nordicsemi.com/Products/Development-tools/nRF-Command-Line-Tools/Download
+.. _nrf_util: https://docs.nordicsemi.com/bundle/nrfutil/page/guides/installing.html
 .. _stm32cubeprog: https://www.st.com/en/development-tools/stm32cubeprog.html


### PR DESCRIPTION
Updated getting started docs.
Fixed path inconsistencies in commands.
Added reference to nRFutil.
Added note for toolchain installation.
Removed note on Infuse access (since it is now public). Improved some step descriptions.