### PR TITLE
rpc: commands: common_coap: fix prototype

### DIFF
--- a/subsys/rpc/commands/bt_file_copy_coap.c
+++ b/subsys/rpc/commands/bt_file_copy_coap.c
@@ -31,7 +31,7 @@ struct net_buf *rpc_command_bt_file_copy_coap(struct net_buf *request)
 	int rc;
 
 	/* Setup arguments for sub-commands */
-	struct rpc_coap_download_request coap_req = {
+	struct rpc_coap_download_v2_request coap_req = {
 		.server_port = req->server_port,
 		.block_timeout_ms = req->block_timeout_ms,
 		.action = RPC_ENUM_FILE_ACTION_FILE_FOR_COPY,
@@ -45,7 +45,7 @@ struct net_buf *rpc_command_bt_file_copy_coap(struct net_buf *request)
 		.ack_period = req->ack_period,
 		.pipelining = req->pipelining,
 	};
-	struct rpc_coap_download_response coap_rsp = {0};
+	struct rpc_coap_download_v2_response coap_rsp = {0};
 	struct rpc_bt_file_copy_basic_response copy_rsp = {0};
 	struct epacket_bt_gatt_connect_params connect_params = {
 		.conn_params = BT_LE_CONN_PARAM_INIT(0x10, 0x15, 0, 400),

--- a/subsys/rpc/commands/coap_download.c
+++ b/subsys/rpc/commands/coap_download.c
@@ -28,6 +28,7 @@
 #include "nrf_modem_delta_dfu.h"
 #endif /* CONFIG_NRF_MODEM_LIB */
 
+#include "common_coap.h"
 #include "common_file_actions.h"
 
 LOG_MODULE_DECLARE(rpc_server, CONFIG_INFUSE_RPC_LOG_LEVEL);

--- a/subsys/rpc/commands/common_coap.h
+++ b/subsys/rpc/commands/common_coap.h
@@ -9,5 +9,5 @@
 #include <infuse/rpc/types.h>
 
 /* Implementation of COAP_DOWNLOAD */
-int rpc_command_coap_download_run(struct rpc_coap_download_request *req, char *resource,
-				  struct rpc_coap_download_response *rsp, int *downloaded);
+int rpc_command_coap_download_run(struct rpc_coap_download_v2_request *req, char *resource,
+				  struct rpc_coap_download_v2_response *rsp, int *downloaded);


### PR DESCRIPTION
`rpc_command_coap_download_run` takes the V2 parameters, not V1.