### PR TITLE
epacket: interface: bt_adv: define `INDOORS` flag

### DIFF
--- a/generated/Kconfig.kv_keys
+++ b/generated/Kconfig.kv_keys
@@ -61,6 +61,12 @@ config KV_STORE_KEY_FIXED_LOCATION
 	help
 	  Fixed global location of the device
 
+config KV_STORE_KEY_BROADCAST_FIXED_INDOORS
+	bool "Enable KV key BROADCAST_FIXED_INDOORS"
+	depends on EPACKET_INTERFACE_BT_ADV
+	help
+	  Device is fixed indoors and should broadcast the fact
+
 config KV_STORE_KEY_WIFI_SSID
 	bool "Enable KV key WIFI_SSID"
 	default y if WIFI

--- a/generated/include/infuse/fs/kv_types.h
+++ b/generated/include/infuse/fs/kv_types.h
@@ -213,6 +213,12 @@ struct kv_fixed_location {
 	struct gcs_location location;
 } __packed;
 
+/** Device is fixed indoors and should broadcast the fact */
+struct kv_broadcast_fixed_indoors {
+	/** Non-zero: Device is indoors */
+	uint8_t indoors;
+} __packed;
+
 /** WiFi network name */
 struct kv_wifi_ssid {
 	/** WiFi network name */
@@ -576,6 +582,8 @@ enum kv_builtin_id {
 	KV_KEY_SECONDARY_REMOTE_PUBLIC_KEY = 8,
 	/** Fixed global location of the device */
 	KV_KEY_FIXED_LOCATION = 10,
+	/** Device is fixed indoors and should broadcast the fact */
+	KV_KEY_BROADCAST_FIXED_INDOORS = 11,
 	/** WiFi network name */
 	KV_KEY_WIFI_SSID = 20,
 	/** WiFi network password */
@@ -667,6 +675,7 @@ enum kv_builtin_size {
 	_KV_KEY_APPLICATION_ACTIVE_SIZE = sizeof(struct kv_application_active),
 	_KV_KEY_SECONDARY_REMOTE_PUBLIC_KEY_SIZE = sizeof(struct kv_secondary_remote_public_key),
 	_KV_KEY_FIXED_LOCATION_SIZE = sizeof(struct kv_fixed_location),
+	_KV_KEY_BROADCAST_FIXED_INDOORS_SIZE = sizeof(struct kv_broadcast_fixed_indoors),
 	_KV_KEY_EPACKET_UDP_PORT_SIZE = sizeof(struct kv_epacket_udp_port),
 	_KV_KEY_LTE_MODEM_IMEI_SIZE = sizeof(struct kv_lte_modem_imei),
 	_KV_KEY_LTE_NETWORKING_MODES_SIZE = sizeof(struct kv_lte_networking_modes),
@@ -699,6 +708,7 @@ enum kv_builtin_size {
 #define _KV_KEY_BOARD_TARGET_TYPE struct kv_board_target
 #define _KV_KEY_SECONDARY_REMOTE_PUBLIC_KEY_TYPE struct kv_secondary_remote_public_key
 #define _KV_KEY_FIXED_LOCATION_TYPE struct kv_fixed_location
+#define _KV_KEY_BROADCAST_FIXED_INDOORS_TYPE struct kv_broadcast_fixed_indoors
 #define _KV_KEY_WIFI_SSID_TYPE struct kv_wifi_ssid
 #define _KV_KEY_WIFI_PSK_TYPE struct kv_wifi_psk
 #define _KV_KEY_WIFI_CHANNELS_TYPE struct kv_wifi_channels
@@ -746,6 +756,8 @@ enum kv_builtin_size {
 	IF_ENABLED(CONFIG_KV_STORE_KEY_SECONDARY_REMOTE_PUBLIC_KEY, \
 		   (1 +)) \
 	IF_ENABLED(CONFIG_KV_STORE_KEY_FIXED_LOCATION, \
+		   (1 +)) \
+	IF_ENABLED(CONFIG_KV_STORE_KEY_BROADCAST_FIXED_INDOORS, \
 		   (1 +)) \
 	IF_ENABLED(CONFIG_KV_STORE_KEY_WIFI_SSID, \
 		   (1 +)) \
@@ -907,6 +919,13 @@ static struct key_value_slot_definition _KV_SLOTS_ARRAY_DEFINE[] = {
 		.flags = KV_FLAGS_REFLECT,
 	},
 #endif /* CONFIG_KV_STORE_KEY_FIXED_LOCATION */
+#ifdef CONFIG_KV_STORE_KEY_BROADCAST_FIXED_INDOORS
+	{
+		.key = KV_KEY_BROADCAST_FIXED_INDOORS,
+		.range = 1,
+		.flags = KV_FLAGS_REFLECT,
+	},
+#endif /* CONFIG_KV_STORE_KEY_BROADCAST_FIXED_INDOORS */
 #ifdef CONFIG_KV_STORE_KEY_WIFI_SSID
 	{
 		.key = KV_KEY_WIFI_SSID,

--- a/include/infuse/epacket/interface/epacket_bt_adv.h
+++ b/include/infuse/epacket/interface/epacket_bt_adv.h
@@ -29,6 +29,12 @@ extern "C" {
 
 #define epacket_bt_adv_frame epacket_v0_versioned_frame_format
 
+/** Bluetooth advertising specific packet flags */
+enum epacket_flags_bt_adv {
+	/** Transmitting device is explicitly indoors */
+	EPACKET_FLAGS_BT_ADV_INDOORS = BIT(0),
+};
+
 /**
  * @brief Request Bluetooth scanning to be suspended
  *
@@ -65,6 +71,13 @@ void epacket_bt_adv_scan_resume(void);
  * @param scan_cb Callback to run on non-Infuse Bluetooth packets
  */
 void epacket_bt_adv_set_fallback_scan_callback(bt_le_scan_cb_t scan_cb);
+
+/**
+ * @brief Set constant interface flags for Bluetooth advertising packets
+ *
+ * @param flags Flags to set
+ */
+void epacket_bt_adv_set_interface_flags(enum epacket_flags_bt_adv flags);
 
 /**
  * @}

--- a/lib/auto/kv_state_observer.c
+++ b/lib/auto/kv_state_observer.c
@@ -9,13 +9,15 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 
+#include <infuse/epacket/interface/epacket_bt_adv.h>
 #include <infuse/fs/kv_store.h>
 #include <infuse/fs/kv_types.h>
 #include <infuse/states.h>
 #include <infuse/time/epoch.h>
 
 #if defined(CONFIG_KV_STORE_KEY_LED_DISABLE_DAILY_TIME_RANGE) ||                                   \
-	defined(CONFIG_KV_STORE_KEY_APPLICATION_ACTIVE)
+	defined(CONFIG_KV_STORE_KEY_APPLICATION_ACTIVE) ||                                         \
+	defined(CONFIG_KV_STORE_KEY_BROADCAST_FIXED_INDOORS)
 #define KV_OBSERVER_CB 1
 
 static void kv_state_obs_value_changed(uint16_t key, const void *data, size_t data_len,
@@ -147,6 +149,20 @@ static void kv_state_obs_value_changed(uint16_t key, const void *data, size_t da
 		}
 	}
 #endif /* CONFIG_KV_STORE_KEY_APPLICATION_ACTIVE */
+#ifdef CONFIG_KV_STORE_KEY_BROADCAST_FIXED_INDOORS
+	const struct kv_broadcast_fixed_indoors *indoors;
+
+	if (key == KV_KEY_BROADCAST_FIXED_INDOORS) {
+		if (data == NULL) {
+			epacket_bt_adv_set_interface_flags(0);
+		} else {
+			indoors = data;
+			epacket_bt_adv_set_interface_flags(
+				indoors->indoors ? EPACKET_FLAGS_BT_ADV_INDOORS : 0);
+		}
+	}
+
+#endif /* CONFIG_KV_STORE_KEY_BROADCAST_FIXED_INDOORS */
 }
 #endif /* KV_OBSERVER_CB */
 
@@ -166,6 +182,14 @@ void kv_state_observer_init_internal(void)
 	/* Evaluate immediately */
 	k_work_schedule(&led_delayable, K_NO_WAIT);
 #endif /* CONFIG_KV_STORE_KEY_LED_DISABLE_DAILY_TIME_RANGE */
+#ifdef CONFIG_KV_STORE_KEY_BROADCAST_FIXED_INDOORS
+	struct kv_broadcast_fixed_indoors indoors;
+
+	if ((KV_STORE_READ(KV_KEY_BROADCAST_FIXED_INDOORS, &indoors) == sizeof(indoors)) &&
+	    indoors.indoors) {
+		epacket_bt_adv_set_interface_flags(EPACKET_FLAGS_BT_ADV_INDOORS);
+	}
+#endif /* CONFIG_KV_STORE_KEY_BROADCAST_FIXED_INDOORS */
 #if defined(CONFIG_KV_STORE_KEY_APPLICATION_ACTIVE)
 	struct kv_application_active active;
 

--- a/scripts/west_commands/cloud_definitions/kv_store.json
+++ b/scripts/west_commands/cloud_definitions/kv_store.json
@@ -174,6 +174,15 @@
                 {"name": "location", "type": "struct gcs_location", "description": "Location"}
             ]
         },
+        "11": {
+            "name": "BROADCAST_FIXED_INDOORS",
+            "description": "Device is fixed indoors and should broadcast the fact",
+            "depends_on": "EPACKET_INTERFACE_BT_ADV",
+            "reflect": true,
+            "fields": [
+                {"name": "indoors", "type": "uint8_t", "description": "Non-zero: Device is indoors"}
+            ]
+        },
         "20": {
             "name": "WIFI_SSID",
             "description": "WiFi network name",

--- a/subsys/epacket/interfaces/epacket_bt_adv.c
+++ b/subsys/epacket/interfaces/epacket_bt_adv.c
@@ -48,6 +48,7 @@ static uint32_t scan_watchdog_timeouts;
 static struct net_buf *adv_set_bufs[CONFIG_BT_EXT_ADV_MAX_ADV_SET];
 static K_FIFO_DEFINE(tx_buf_queue);
 static struct bt_le_ext_adv *adv_set;
+static enum epacket_flags_bt_adv interface_flags;
 static bool adv_set_active;
 static uint8_t scan_suspended;
 static K_SEM_DEFINE(scan_control, 1, 1);
@@ -195,6 +196,11 @@ static void adv_set_complete(struct bt_le_ext_adv *adv, struct bt_le_ext_adv_sen
 
 static void epacket_bt_adv_send(const struct device *dev, struct net_buf *buf)
 {
+	struct epacket_tx_metadata *tx_meta = net_buf_user_data(buf);
+
+	/* Apply constant interface flags */
+	tx_meta->flags |= interface_flags;
+
 	/* Encrypt the payload */
 	if (epacket_bt_adv_encrypt(buf) < 0) {
 		LOG_WRN("Failed to encrypt");
@@ -345,6 +351,11 @@ void epacket_bt_adv_scan_resume(void)
 		}
 	}
 	k_sem_give(&scan_control);
+}
+
+void epacket_bt_adv_set_interface_flags(enum epacket_flags_bt_adv flags)
+{
+	interface_flags = flags & EPACKET_FLAGS_INTERFACE_MASK;
 }
 
 static int epacket_bt_adv_init(const struct device *dev)

--- a/tests/lib/auto/kv_state_observer/Kconfig
+++ b/tests/lib/auto/kv_state_observer/Kconfig
@@ -1,0 +1,6 @@
+# Test specific overrides
+
+config KV_STORE_KEY_BROADCAST_FIXED_INDOORS
+	bool "No dependencies"
+
+source "Kconfig.zephyr"

--- a/tests/lib/auto/kv_state_observer/src/main.c
+++ b/tests/lib/auto/kv_state_observer/src/main.c
@@ -16,8 +16,16 @@
 #include <infuse/fs/kv_types.h>
 #include <infuse/states.h>
 #include <infuse/time/epoch.h>
+#include <infuse/epacket/interface/epacket_bt_adv.h>
 
 void kv_state_observer_init_internal(void);
+
+static enum epacket_flags_bt_adv set_flags;
+
+void epacket_bt_adv_set_interface_flags(enum epacket_flags_bt_adv flags)
+{
+	set_flags = flags;
+}
 
 static void set_now(uint32_t gps_time)
 {
@@ -295,6 +303,81 @@ ZTEST(kv_state_observer, test_application_active_boot)
 	zassert_false(infuse_state_get(INFUSE_STATE_APPLICATION_ACTIVE));
 }
 
+ZTEST(kv_state_observer, test_broadcast_fixed_indoors)
+{
+	struct kv_broadcast_fixed_indoors indoors;
+	int rc;
+
+	if (!IS_ENABLED(CONFIG_KV_STORE_KEY_BROADCAST_FIXED_INDOORS)) {
+		ztest_test_skip();
+		return;
+	}
+
+	/* Write not indoors */
+	indoors.indoors = 0x00;
+	rc = KV_STORE_WRITE(KV_KEY_BROADCAST_FIXED_INDOORS, &indoors);
+	zassert_equal(sizeof(indoors), rc);
+	zassert_equal(0, set_flags);
+
+	/* Delete while not indoors */
+	rc = kv_store_delete(KV_KEY_BROADCAST_FIXED_INDOORS);
+	zassert_equal(0, rc);
+	zassert_equal(0, set_flags);
+
+	/* Write indoors */
+	indoors.indoors = 0x01;
+	rc = KV_STORE_WRITE(KV_KEY_BROADCAST_FIXED_INDOORS, &indoors);
+	zassert_equal(sizeof(indoors), rc);
+	zassert_equal(EPACKET_FLAGS_BT_ADV_INDOORS, set_flags);
+
+	/* Write not indoors */
+	indoors.indoors = 0x00;
+	rc = KV_STORE_WRITE(KV_KEY_BROADCAST_FIXED_INDOORS, &indoors);
+	zassert_equal(sizeof(indoors), rc);
+	zassert_equal(0, set_flags);
+
+	/* Write different indoors */
+	indoors.indoors = 0xA9;
+	rc = KV_STORE_WRITE(KV_KEY_BROADCAST_FIXED_INDOORS, &indoors);
+	zassert_equal(sizeof(indoors), rc);
+	zassert_equal(EPACKET_FLAGS_BT_ADV_INDOORS, set_flags);
+
+	/* Delete while indoors */
+	rc = kv_store_delete(KV_KEY_BROADCAST_FIXED_INDOORS);
+	zassert_equal(0, rc);
+	zassert_equal(0, set_flags);
+}
+
+ZTEST(kv_state_observer, test_broadcast_fixed_indoors_boot)
+{
+	struct kv_broadcast_fixed_indoors indoors;
+	int rc;
+
+	if (!IS_ENABLED(CONFIG_KV_STORE_KEY_BROADCAST_FIXED_INDOORS)) {
+		/* No flags set */
+		zassert_equal(0, set_flags);
+		return;
+	}
+
+	/* Nothing set when not present on boot */
+	zassert_equal(0, set_flags);
+
+	/* Booting with indoors set */
+	indoors.indoors = 0xA9;
+	rc = KV_STORE_WRITE(KV_KEY_BROADCAST_FIXED_INDOORS, &indoors);
+	zassert_equal(sizeof(indoors), rc);
+	kv_state_observer_init_internal();
+	zassert_equal(EPACKET_FLAGS_BT_ADV_INDOORS, set_flags);
+
+	/* Booting with indoors cleared */
+	indoors.indoors = 0x00;
+	rc = KV_STORE_WRITE(KV_KEY_BROADCAST_FIXED_INDOORS, &indoors);
+	zassert_equal(sizeof(indoors), rc);
+	set_flags = 0;
+	kv_state_observer_init_internal();
+	zassert_equal(0, set_flags);
+}
+
 void test_init(void *fixture)
 {
 	struct timeutil_sync_instant reference = {
@@ -304,6 +387,7 @@ void test_init(void *fixture)
 
 	kv_store_delete(KV_KEY_LED_DISABLE_DAILY_TIME_RANGE);
 	kv_store_delete(KV_KEY_APPLICATION_ACTIVE);
+	kv_store_delete(KV_KEY_BROADCAST_FIXED_INDOORS);
 	epoch_time_set_reference(TIME_SOURCE_NONE, &reference);
 	kv_state_observer_init_internal();
 }

--- a/tests/lib/auto/kv_state_observer/testcase.yaml
+++ b/tests/lib/auto/kv_state_observer/testcase.yaml
@@ -14,7 +14,11 @@ tests:
   libraries.auto.kv_state_observer.app_active:
     extra_configs:
       - CONFIG_KV_STORE_KEY_APPLICATION_ACTIVE=y
+  libraries.auto.kv_state_observer.fixed_indoors:
+    extra_configs:
+      - CONFIG_KV_STORE_KEY_BROADCAST_FIXED_INDOORS=y
   libraries.auto.kv_state_observer.all:
     extra_configs:
       - CONFIG_KV_STORE_KEY_LED_DISABLE_DAILY_TIME_RANGE=y
       - CONFIG_KV_STORE_KEY_APPLICATION_ACTIVE=y
+      - CONFIG_KV_STORE_KEY_BROADCAST_FIXED_INDOORS=y


### PR DESCRIPTION
Define an interface specific flag to allow devices to broadcast that
the signal is originating from indoors. Observing devices can use this
information to modify their own behaviour. For example assuming that
because the transmitter is indoors there is a good chance they are as
well, and therefore skipping GNSS locks that are unlikely to succeed.