### PR TITLE
manifest: update memfault

### DIFF
--- a/kconfig/Kconfig.defaults.core
+++ b/kconfig/Kconfig.defaults.core
@@ -251,6 +251,8 @@ configdefault MEMFAULT_FS_BYTES_FREE_METRIC
 	default n
 configdefault MEMFAULT_METRICS
 	default n
+configdefault MEMFAULT_MCUMGR_GRP
+	default n
 configdefault MEMFAULT_HEAP_STATS
 	default n
 configdefault MEMFAULT_FAULT_HANDLER_RETURN
@@ -271,4 +273,12 @@ endchoice
 # Temporary option until Memfault updated
 # https://github.com/memfault/memfault-firmware-sdk/issues/96
 config PARTITION_MANAGER_ENABLED
+	bool
+config MBEDTLS_PEM_PARSE_C
+	bool
+config MBEDTLS_PEM_WRITE_C
+	bool
+config NRF_CLOUD_COAP_MAX_USER_OPTIONS
+	bool
+config MODEM_JWT
 	bool

--- a/west.yml
+++ b/west.yml
@@ -45,7 +45,7 @@ manifest:
       import: true
     - name: memfault-firmware-sdk
       path: modules/lib/memfault
-      revision: 1.30.2
+      revision: 1.37.1
       remote: memfault
 
   self:


### PR DESCRIPTION
Update memfault to the latest version. The new MCUmgr group is disabled by default as it depends on `MEMFAULT_PROJECT_KEY`, which is not expressed in Kconfig and we don't use by default.

Add more workarounds for NCS symbols used by Memfault.