### PR TITLE
rpc: commands: data_logger_erase: unconditional erase

### DIFF
--- a/generated/include/infuse/rpc/types.h
+++ b/generated/include/infuse/rpc/types.h
@@ -843,7 +843,7 @@ struct rpc_data_logger_erase_request {
 	struct infuse_rpc_req_header header;
 	/** Data logger to erase */
 	uint8_t logger;
-	/** Erase entire logger space, even empty blocks */
+	/** Erase entire logger space, even empty blocks (0xAA == ignore init failures) */
 	uint8_t erase_empty;
 } __packed;
 

--- a/scripts/west_commands/cloud_definitions/rpc.json
+++ b/scripts/west_commands/cloud_definitions/rpc.json
@@ -537,7 +537,7 @@
             "default_auth": "EPACKET_AUTH_DEVICE",
             "request_params": [
                 {"name": "logger", "type": "enum rpc_enum_data_logger", "description": "Data logger to erase"},
-                {"name": "erase_empty", "type": "uint8_t", "description": "Erase entire logger space, even empty blocks"}
+                {"name": "erase_empty", "type": "uint8_t", "description": "Erase entire logger space, even empty blocks (0xAA == ignore init failures)"}
             ],
             "response_params": [
             ]

--- a/subsys/data_logger/backends/flash_map.c
+++ b/subsys/data_logger/backends/flash_map.c
@@ -11,6 +11,8 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/flash.h>
 #include <zephyr/storage/flash_map.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
 
 #include <infuse/data_logger/logger.h>
 
@@ -108,6 +110,26 @@ static int logger_flash_map_reset(const struct device *dev, uint32_t block_hint,
 	return 0;
 }
 
+#ifdef CONFIG_PM_DEVICE
+static int flash_map_pm_control(const struct device *dev, enum pm_device_action action)
+{
+	struct dl_flash_map_data *data = dev->data;
+	int rc = 0;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		rc = pm_device_runtime_put(data->area->fa_dev);
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		rc = pm_device_runtime_get(data->area->fa_dev);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+	return rc;
+}
+#endif /* CONFIG_PM_DEVICE */
+
 /* Need to hook into this function when testing */
 IF_DISABLED(CONFIG_ZTEST, (static))
 int logger_flash_map_init(const struct device *dev)
@@ -135,7 +157,12 @@ int logger_flash_map_init(const struct device *dev)
 	}
 
 	/* Common init function */
-	return data_logger_common_init(dev);
+	rc = data_logger_common_init(dev);
+
+	/* Always want PM enabled on this device */
+	pm_device_init_suspended(dev);
+	(void)pm_device_runtime_enable(dev);
+	return rc;
 }
 
 const struct data_logger_api data_logger_flash_map_api = {
@@ -160,8 +187,10 @@ const struct data_logger_api data_logger_flash_map_api = {
 		.block_addr_shift = LOG2(DT_INST_PROP(inst, block_size)),                          \
 	};                                                                                         \
 	static struct dl_flash_map_data data##inst;                                                \
-	DEVICE_DT_INST_DEFINE(inst, logger_flash_map_init, NULL, &data##inst, &config##inst,       \
-			      POST_KERNEL, 80, &data_logger_flash_map_api);
+	PM_DEVICE_DT_INST_DEFINE(inst, flash_map_pm_control);                                      \
+	DEVICE_DT_INST_DEFINE(inst, logger_flash_map_init, PM_DEVICE_DT_INST_GET(inst),            \
+			      &data##inst, &config##inst, POST_KERNEL, 80,                         \
+			      &data_logger_flash_map_api);
 
 #define DATA_LOGGER_DEFINE_WRAPPER(inst)                                                           \
 	IF_ENABLED(DATA_LOGGER_DEPENDENCIES_MET(DT_DRV_INST(inst)), (DATA_LOGGER_DEFINE(inst)))

--- a/subsys/rpc/commands/data_logger_erase.c
+++ b/subsys/rpc/commands/data_logger_erase.c
@@ -29,6 +29,7 @@ struct net_buf *rpc_command_data_logger_erase(struct net_buf *request)
 	struct rpc_data_logger_erase_request *req = (void *)request->data;
 	struct rpc_data_logger_erase_response rsp = {0};
 	const struct device *logger;
+	bool init_override = req->erase_empty == 0xAA;
 	bool erase_all = req->erase_empty;
 	int rc = 0;
 
@@ -54,7 +55,7 @@ struct net_buf *rpc_command_data_logger_erase(struct net_buf *request)
 	req_meta = NULL;
 
 	/* Ensure device initialised properly */
-	if (!device_is_ready(logger)) {
+	if (!device_is_ready(logger) && !init_override) {
 		rc = -EBADF;
 		goto end;
 	}

--- a/tests/subsys/data_logger/backends/flash_map/app.overlay
+++ b/tests/subsys/data_logger/backends/flash_map/app.overlay
@@ -13,6 +13,8 @@
 		#size-cells = <1>;
 		erase-value = <0xff>;
 
+		zephyr,pm-device-runtime-auto;
+
 		flash_sim0: flash_sim@0 {
 			compatible = "soc-nv-flash";
 			reg = <0x00000000 DT_SIZE_K(4)>;

--- a/tests/subsys/data_logger/backends/flash_map/src/main.c
+++ b/tests/subsys/data_logger/backends/flash_map/src/main.c
@@ -12,6 +12,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/flash.h>
 #include <zephyr/drivers/flash/flash_simulator.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
 
 #include <infuse/data_logger/logger.h>
 
@@ -461,6 +463,32 @@ ZTEST(data_logger_flash_map, test_erase_exclusion)
 	zassert_equal(4, state.current_block);
 }
 
+ZTEST(data_logger_flash_map, test_pm)
+{
+	const struct device *sim_flash = DEVICE_DT_GET(DT_NODELABEL(sim_flash));
+	const struct device *logger = DEVICE_DT_GET(NODE);
+	enum pm_device_state state;
+
+	if (!IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
+		ztest_test_skip();
+		return;
+	}
+
+	/* Suspended by default */
+	zassert_equal(0, pm_device_state_get(logger, &state));
+	zassert_equal(PM_DEVICE_STATE_SUSPENDED, state);
+	zassert_equal(0, pm_device_state_get(sim_flash, &state));
+	zassert_equal(PM_DEVICE_STATE_SUSPENDED, state);
+
+	/* Logger PM control defers to */
+	zassert_equal(0, pm_device_runtime_get(logger));
+	zassert_equal(0, pm_device_state_get(sim_flash, &state));
+	zassert_equal(PM_DEVICE_STATE_ACTIVE, state);
+	zassert_equal(0, pm_device_runtime_put(logger));
+	zassert_equal(0, pm_device_state_get(sim_flash, &state));
+	zassert_equal(PM_DEVICE_STATE_SUSPENDED, state);
+}
+
 static bool test_data_init(const void *global_state)
 {
 	flash_buffer = flash_simulator_get_memory(DEVICE_DT_GET(DT_NODELABEL(sim_flash)),
@@ -468,4 +496,10 @@ static bool test_data_init(const void *global_state)
 	return true;
 }
 
-ZTEST_SUITE(data_logger_flash_map, test_data_init, NULL, NULL, NULL, NULL);
+static void after_fn(void *unused)
+{
+	/* Small delay to allow PM to release */
+	k_sleep(K_MSEC(200));
+}
+
+ZTEST_SUITE(data_logger_flash_map, test_data_init, NULL, NULL, after_fn, NULL);

--- a/tests/subsys/data_logger/backends/flash_map/testcase.yaml
+++ b/tests/subsys/data_logger/backends/flash_map/testcase.yaml
@@ -9,6 +9,15 @@ tests:
       - qemu_cortex_m3
     integration_platforms:
       - qemu_cortex_m3
+  data_logger.flash_map.pm:
+    platform_allow:
+      - mps2/an385
+      - qemu_cortex_m3
+    integration_platforms:
+      - qemu_cortex_m3
+    extra_configs:
+      - CONFIG_PM_DEVICE=y
+      - CONFIG_PM_DEVICE_RUNTIME=y
   data_logger.flash_map.large:
     platform_allow:
       - qemu_cortex_m3

--- a/tests/subsys/rpc/commands/data_logger/src/main.c
+++ b/tests/subsys/rpc/commands/data_logger/src/main.c
@@ -163,7 +163,7 @@ static void send_tdf_data_logger_flush_command(uint32_t request_id, uint8_t logg
 	epacket_dummy_receive(epacket_dummy, &header, &params, sizeof(params));
 }
 
-static void send_data_logger_erase_command(uint32_t request_id, uint8_t logger, bool erase_empty)
+static void send_data_logger_erase_command(uint32_t request_id, uint8_t logger, uint8_t erase_mode)
 {
 	const struct device *epacket_dummy = DEVICE_DT_GET(DT_NODELABEL(epacket_dummy));
 	struct epacket_dummy_frame header = {
@@ -178,7 +178,7 @@ static void send_data_logger_erase_command(uint32_t request_id, uint8_t logger, 
 				.command_id = RPC_ID_DATA_LOGGER_ERASE,
 			},
 		.logger = logger,
-		.erase_empty = erase_empty,
+		.erase_empty = erase_mode,
 	};
 
 	/* Push command at RPC server */
@@ -672,15 +672,23 @@ ZTEST(rpc_command_data_logger, test_data_logger_erase_invalid)
 	const struct device *flash_logger = DEVICE_DT_GET(DT_NODELABEL(data_logger_flash));
 	struct net_buf *rsp;
 
-	send_data_logger_erase_command(0x1234, UINT8_MAX, false);
+	send_data_logger_erase_command(0x1234, UINT8_MAX, 0x00);
 	rsp = expect_rpc_response(0x1234, RPC_ID_DATA_LOGGER_ERASE, -ENODEV);
 	net_buf_unref(rsp);
 
 	/* Pretend logger failed to initialise */
 	flash_logger->state->init_res += 1;
 	/* Try to erase */
-	send_data_logger_erase_command(0x1234, RPC_ENUM_DATA_LOGGER_FLASH_ONBOARD, false);
-	rsp = expect_rpc_response(0x1234, RPC_ID_DATA_LOGGER_ERASE, -EBADF);
+	send_data_logger_erase_command(0x1235, RPC_ENUM_DATA_LOGGER_FLASH_ONBOARD, 0x00);
+	rsp = expect_rpc_response(0x1235, RPC_ID_DATA_LOGGER_ERASE, -EBADF);
+	net_buf_unref(rsp);
+	/* Try to erase full */
+	send_data_logger_erase_command(0x1236, RPC_ENUM_DATA_LOGGER_FLASH_ONBOARD, 0x01);
+	rsp = expect_rpc_response(0x1236, RPC_ID_DATA_LOGGER_ERASE, -EBADF);
+	net_buf_unref(rsp);
+	/* Erase with override */
+	send_data_logger_erase_command(0x1237, RPC_ENUM_DATA_LOGGER_FLASH_ONBOARD, 0xAA);
+	rsp = expect_rpc_response(0x1237, RPC_ID_DATA_LOGGER_ERASE, 0);
 	net_buf_unref(rsp);
 	/* Restore init result */
 	flash_logger->state->init_res -= 1;
@@ -708,7 +716,7 @@ ZTEST(rpc_command_data_logger, test_data_logger_erase)
 	zassert_equal(8 * 512, state.bytes_logged);
 
 	/* Erase request */
-	send_data_logger_erase_command(0x1235, RPC_ENUM_DATA_LOGGER_FLASH_ONBOARD, true);
+	send_data_logger_erase_command(0x1235, RPC_ENUM_DATA_LOGGER_FLASH_ONBOARD, 0x01);
 	rsp = expect_rpc_response(0x1235, RPC_ID_DATA_LOGGER_ERASE, 0);
 	net_buf_unref(rsp);
 


### PR DESCRIPTION
Add an override mode to erase the entire flash even if the data logger failed to initialise properly. This can be required to recover a flash chip if the initial search is always failing on boot.