### PR TITLE
manifest: update zephyr fork

### DIFF
--- a/apps/gateway_lte/src/main.c
+++ b/apps/gateway_lte/src/main.c
@@ -290,13 +290,6 @@ static void led_pulse_dt(const struct gpio_dt_spec *spec, k_timeout_t pulse_dura
 
 int main(void)
 {
-#if defined(CONFIG_NRF_MODEM_LIB)
-	struct net_if *iface = net_if_get_first_by_type(&(NET_L2_GET_NAME(OFFLOADED_NETDEV)));
-#elif defined(CONFIG_NET_L2_PPP)
-	struct net_if *iface = net_if_get_first_by_type(&(NET_L2_GET_NAME(PPP)));
-#else
-#error Unknown LTE modem network interface
-#endif
 	const struct device *bt_adv = DEVICE_DT_GET(DT_NODELABEL(epacket_bt_adv));
 	const struct device *bt_central = DEVICE_DT_GET(DT_NODELABEL(epacket_bt_central));
 	const struct device *udp = DEVICE_DT_GET(DT_NODELABEL(epacket_udp));
@@ -310,7 +303,9 @@ int main(void)
 	struct kv_store_cb kv_cb = {
 		.value_changed = kv_value_changed,
 	};
+	struct lte_modem_network_state lte_state;
 	uint16_t udp_payload_size;
+	bool lte_modem_active;
 	int rc;
 
 #if CONFIG_LTE_GATEWAY_DEFAULT_MAXIMUM_UPLINK_THROUGHPUT_KBPS > 0
@@ -380,6 +375,13 @@ int main(void)
 	epacket_receive(udp, K_FOREVER);
 
 #ifdef CONFIG_MODEM_CELLULAR
+#if defined(CONFIG_NRF_MODEM_LIB)
+	struct net_if *iface = net_if_get_first_by_type(&(NET_L2_GET_NAME(OFFLOADED_NETDEV)));
+#elif defined(CONFIG_NET_L2_PPP)
+	struct net_if *iface = net_if_get_first_by_type(&(NET_L2_GET_NAME(PPP)));
+#else
+#error Unknown LTE modem network interface
+#endif
 	/* For now the Cellular Modem abstraction is not linked to a connection manager */
 	net_if_up(iface);
 #else
@@ -411,8 +413,20 @@ int main(void)
 	while (true) {
 		k_sleep(K_SECONDS(5));
 
+		lte_modem_monitor_network_state(&lte_state);
+		switch (lte_state.nw_reg_status) {
+		case CELLULAR_REGISTRATION_SEARCHING:
+		case CELLULAR_REGISTRATION_REGISTERED_HOME:
+		case CELLULAR_REGISTRATION_REGISTERED_ROAMING:
+		case CELLULAR_REGISTRATION_DENIED:
+			lte_modem_active = true;
+			break;
+		default:
+			lte_modem_active = false;
+		}
+
 		udp_payload_size = epacket_interface_max_packet_size(udp);
-		if (!net_if_flag_is_set(iface, NET_IF_LOWER_UP)) {
+		if (!lte_modem_active) {
 			led_pulse_dt(&led0, K_SECONDS(1));
 		} else if (udp_payload_size > 0) {
 			led_pulse_dt(&led1, K_MSEC(200));

--- a/lib/modem_monitor/modem_cellular/cellular_modem_monitor.c
+++ b/lib/modem_monitor/modem_cellular/cellular_modem_monitor.c
@@ -30,6 +30,7 @@ static struct {
 #ifdef CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG
 	uint8_t network_state_loggers;
 #endif /* CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG */
+	struct k_work_delayable shutdown_fallback;
 	bool at_link_dead;
 } monitor;
 
@@ -142,6 +143,14 @@ static void network_status_changed(const struct device *dev,
 	monitor.network_state.cell.rsrq = ns->cell.lte.rsrq;
 }
 
+static void modem_shutdown_fallback(struct k_work *work)
+{
+	const struct device *modem = DEVICE_DT_GET(DT_ALIAS(modem));
+
+	LOG_ERR("Clean modem shutdown timed out, rebooting");
+	infuse_reboot(INFUSE_REBOOT_LTE_MODEM_FAULT, (uintptr_t)modem, 0xA800DEAD);
+}
+
 static void comms_check_result(const struct device *dev,
 			       const struct cellular_evt_modem_comms_check_result *ccr)
 {
@@ -161,6 +170,8 @@ static void comms_check_result(const struct device *dev,
 	/* Suspend the modem */
 	monitor.at_link_dead = true;
 	net_if_down(iface);
+	/* Fallback reboot if interface doesn't go down nicely */
+	k_work_schedule(&monitor.shutdown_fallback, K_SECONDS(30));
 }
 
 static void modem_suspended(const struct device *dev)
@@ -258,6 +269,8 @@ int lte_modem_monitor_init(void)
 	}
 
 #endif /* CONFIG_INFUSE_MODEM_MONITOR_DEFAULT_PDP_APN_SET */
+
+	k_work_init_delayable(&monitor.shutdown_fallback, modem_shutdown_fallback);
 
 	/* Setup KV callbacks */
 	monitor.lte_kv_cb.value_changed = lte_kv_value_changed;

--- a/west.yml
+++ b/west.yml
@@ -14,7 +14,7 @@ manifest:
 
   projects:
     - name: zephyr
-      revision: ee6360c90dd22d09a487e728e1120430c596613c
+      revision: e2159df1ad8e4e0a70c7274e5ece14f220026172
       # Limit imported repositories to reduce clone time
       import:
         name-allowlist:


### PR DESCRIPTION
Update zephyr fork to fix transient Telit GNSS failures being able to reboot the primary application, and eliminate some error states by reordering the cellular modem connection state machine.