### PR TITLE
epacket: bt_central: setup function for external users

### DIFF
--- a/include/infuse/epacket/interface/epacket_bt_central.h
+++ b/include/infuse/epacket/interface/epacket_bt_central.h
@@ -76,11 +76,21 @@ int epacket_bt_gatt_connect(struct bt_conn **conn, struct epacket_bt_gatt_connec
 			    struct epacket_read_response *security, bool *already);
 
 /**
+ * @brief Setup @ref epacket_bt_gatt_notify_recv_func
+ *
+ * @param conn Connection object. Must not be NULL.
+ */
+void epacket_bt_gatt_notify_init(struct bt_conn *conn);
+
+/**
  * @brief Infuse-IoT Bluetooth GATT characteristic notification handle function
  *
  * Public API function so that connections setup through a function other than
  * @ref epacket_bt_gatt_connect can hook the connection up as an ePacket data source
  * dynamically.
+ *
+ * @note Users must ensure that @ref epacket_bt_gatt_notify_init is called before any data
+ *       is received on the connection.
  *
  * @param conn Connection object. May be NULL, indicating that the peer is
  *             being unpaired

--- a/subsys/epacket/interfaces/epacket_bt_central.c
+++ b/subsys/epacket/interfaces/epacket_bt_central.c
@@ -112,6 +112,17 @@ static void conn_terminated_cb(struct bt_conn *conn, int reason, void *user_data
 	k_work_cancel_delayable(&infuse_conn[idx].term_worker);
 }
 
+void epacket_bt_gatt_notify_init(struct bt_conn *conn)
+{
+	struct infuse_connection_state *s;
+	uint8_t idx;
+
+	/* Ensure the internal work objects aren't scheduled */
+	idx = bt_conn_index(conn);
+	s = &infuse_conn[idx];
+	s->inactivity_timeout = K_FOREVER;
+}
+
 uint8_t epacket_bt_gatt_notify_recv_func(struct bt_conn *conn,
 					 struct bt_gatt_subscribe_params *params, const void *data,
 					 uint16_t length)


### PR DESCRIPTION
Add a required setup function for `epacket_bt_gatt_notify_recv_func` if used by external code to setup the interface internals properly, as `epacket_bt_gatt_connect` is not being run.