### PR TITLE
manifest: update zephyr fork

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -14,7 +14,7 @@ manifest:
 
   projects:
     - name: zephyr
-      revision: e2159df1ad8e4e0a70c7274e5ece14f220026172
+      revision: dca2f227b320ba99aa0f7ca4ff06301f634f81cb
       # Limit imported repositories to reduce clone time
       import:
         name-allowlist:


### PR DESCRIPTION
Update Zephyr fork with fix to make the older Telit LE910 AP module work with the new "dial PPP after registration" behaviour of the driver.