### PR TITLE
manifest: update zephyr fork

### DIFF
--- a/include/infuse/auto/location_timezone.h
+++ b/include/infuse/auto/location_timezone.h
@@ -47,6 +47,15 @@ int location_timezone(int8_t *timezone);
  */
 int location_local_time(uint32_t *local_time_seconds);
 
+#ifdef CONFIG_ZTEST
+
+/**
+ * @brief Reset location knowledge of the module for testing purposes
+ */
+void location_timezone_reset(void);
+
+#endif /* CONFIG_ZTEST */
+
 /**
  * @}
  */

--- a/lib/auto/location_timezone.c
+++ b/lib/auto/location_timezone.c
@@ -25,6 +25,17 @@ static int8_t current_timezone = INT8_MIN;
 
 LOG_MODULE_REGISTER(loc_tz, CONFIG_LOCATION_TIMEZONE_LOG_LEVEL);
 
+#ifdef CONFIG_ZTEST
+
+void location_timezone_reset(void)
+{
+	LOG_INF("Resetting back to no timezone knowledge");
+	current_timezone_minutes = INT16_MIN;
+	current_timezone = INT8_MIN;
+}
+
+#endif /* CONFIG_ZTEST */
+
 int location_timezone(int8_t *timezone)
 {
 	if (current_timezone == INT8_MIN) {

--- a/tests/lib/auto/location_timezone/src/main.c
+++ b/tests/lib/auto/location_timezone/src/main.c
@@ -84,6 +84,11 @@ ZTEST(location_timezone, test_timezone)
 	zassert_equal(0, location_local_time(&local_time));
 	zassert_equal(-2, timezone);
 	zassert_equal(utc_time + (-2 * SEC_PER_HOUR), local_time);
+
+	/* Reset knowledge */
+	location_timezone_reset();
+	zassert_equal(-EAGAIN, location_timezone(&timezone));
+	zassert_equal(-EAGAIN, location_local_time(&local_time));
 }
 
 ZTEST_SUITE(location_timezone, NULL, NULL, NULL, NULL, NULL);

--- a/west.yml
+++ b/west.yml
@@ -14,7 +14,7 @@ manifest:
 
   projects:
     - name: zephyr
-      revision: 6cf648c8cf5286564c67e1b30d98c601f2001691
+      revision: 42272e5572d85f2b2a02a604f85d2ddac1e8bb1a
       # Limit imported repositories to reduce clone time
       import:
         name-allowlist:


### PR DESCRIPTION
Update zephyr fork to fix potential premature timeouts in the SPI NAND flash driver.