### PR TITLE
generated: define RPC for shipping mode

### DIFF
--- a/generated/Kconfig.rpc_commands
+++ b/generated/Kconfig.rpc_commands
@@ -381,6 +381,16 @@ config INFUSE_RPC_COMMAND_TDF_DATA_LOGGER_FLUSH_REQUIRED_AUTH
 	depends on INFUSE_RPC_COMMAND_TDF_DATA_LOGGER_FLUSH
 	default 2
 
+config INFUSE_RPC_COMMAND_SHIPPING_MODE
+	bool "Enable RPC shipping_mode"
+	help
+	  Enter/Exit shipping mode on a device
+
+config INFUSE_RPC_COMMAND_SHIPPING_MODE_REQUIRED_AUTH
+	int "Required authorisation level to run shipping_mode"
+	depends on INFUSE_RPC_COMMAND_SHIPPING_MODE
+	default 2
+
 config INFUSE_RPC_COMMAND_BT_CONNECT_INFUSE
 	bool "Enable RPC bt_connect_infuse"
 	depends on EPACKET_INTERFACE_BT_CENTRAL

--- a/generated/include/infuse/rpc/commands_impl.h
+++ b/generated/include/infuse/rpc/commands_impl.h
@@ -307,6 +307,15 @@ struct net_buf *rpc_command_annotate(struct net_buf *request);
 struct net_buf *rpc_command_tdf_data_logger_flush(struct net_buf *request);
 
 /**
+ * @brief Run shipping_mode RPC
+ *
+ * @param request @ref INFUSE_RPC_CMD packet to respond to
+ *
+ * @return struct net_buf* @ref INFUSE_RPC_RSP packet buffer
+ */
+struct net_buf *rpc_command_shipping_mode(struct net_buf *request);
+
+/**
  * @brief Run bt_connect_infuse RPC
  *
  * @param request @ref INFUSE_RPC_CMD packet to respond to

--- a/generated/include/infuse/rpc/types.h
+++ b/generated/include/infuse/rpc/types.h
@@ -517,6 +517,8 @@ enum rpc_builtin_id {
 	RPC_ID_ANNOTATE = 41,
 	/** Write an annotation to the device */
 	RPC_ID_TDF_DATA_LOGGER_FLUSH = 42,
+	/** Enter/Exit shipping mode on a device */
+	RPC_ID_SHIPPING_MODE = 43,
 	/** Connect to an Infuse-IoT Bluetooth device */
 	RPC_ID_BT_CONNECT_INFUSE = 50,
 	/** Disconnect from a Bluetooth device */
@@ -1137,6 +1139,19 @@ struct rpc_tdf_data_logger_flush_response {
 	uint8_t num;
 	/** Flush status */
 	struct rpc_struct_data_logger_flushed flushed[];
+} __packed;
+
+/** Enter/Exit shipping mode on a device */
+struct rpc_shipping_mode_request {
+	struct infuse_rpc_req_header header;
+	/** Non-zero to enter shipping mode, zero to exit */
+	uint8_t enter;
+} __packed;
+
+struct rpc_shipping_mode_response {
+	struct infuse_rpc_rsp_header header;
+	/** Expected delay to enter/exit shipping mode */
+	uint32_t expected_delay_ms;
 } __packed;
 
 /** Connect to an Infuse-IoT Bluetooth device */

--- a/generated/rpc_command_runner.c
+++ b/generated/rpc_command_runner.c
@@ -298,6 +298,13 @@ void rpc_command_runner(struct net_buf *request)
 		}
 		break;
 #endif /* CONFIG_INFUSE_RPC_COMMAND_TDF_DATA_LOGGER_FLUSH */
+#ifdef CONFIG_INFUSE_RPC_COMMAND_SHIPPING_MODE
+	case RPC_ID_SHIPPING_MODE:
+		if (AUTHORISED(auth, SHIPPING_MODE)) { /* GCOVR_EXCL_BR_LINE */
+			response = rpc_command_shipping_mode(request);
+		}
+		break;
+#endif /* CONFIG_INFUSE_RPC_COMMAND_SHIPPING_MODE */
 #ifdef CONFIG_INFUSE_RPC_COMMAND_BT_CONNECT_INFUSE
 	case RPC_ID_BT_CONNECT_INFUSE:
 		if (AUTHORISED(auth, BT_CONNECT_INFUSE)) { /* GCOVR_EXCL_BR_LINE */

--- a/scripts/west_commands/cloud_definitions/rpc.json
+++ b/scripts/west_commands/cloud_definitions/rpc.json
@@ -774,7 +774,17 @@
                 {"name": "flushed", "type": "struct rpc_struct_data_logger_flushed", "num": 0, "description": "Flush status", "counted_by": "num"}
             ]
         },
-
+        "43": {
+            "name": "shipping_mode",
+            "description": "Enter/Exit shipping mode on a device",
+            "default_auth": "EPACKET_AUTH_DEVICE",
+            "request_params": [
+                {"name": "enter", "type": "uint8_t", "description": "Non-zero to enter shipping mode, zero to exit"}
+            ],
+            "response_params": [
+                {"name": "expected_delay_ms", "type": "uint32_t", "description": "Expected delay to enter/exit shipping mode"}
+            ]
+        },
         "50": {
             "name": "bt_connect_infuse",
             "description": "Connect to an Infuse-IoT Bluetooth device",

--- a/tests/subsys/algorithms/build_system/src/main.c
+++ b/tests/subsys/algorithms/build_system/src/main.c
@@ -21,7 +21,7 @@
 INFUSE_ZBUS_CHAN_DEFINE(INFUSE_ZBUS_CHAN_BATTERY);
 
 #ifdef CONFIG_TEST_ALGORITHM_BUILD_LLEXT
-static uint8_t test_algorithm[] __aligned(sizeof(void *)) = {
+static const uint8_t test_algorithm[] __aligned(sizeof(void *)) = {
 #include "test_algorithm.inc"
 };
 #endif /* CONFIG_TEST_ALGORITHM_BUILD_LLEXT */


### PR DESCRIPTION
Define an RPC for entering shipping mode. No implementation is provided, as this functionality is device specific, not linked to an API.