### PR TITLE
rpc: commands: common_file_actions: extract DFU reboot

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -143,7 +143,7 @@ jobs:
             -T infuse-sdk/tests --coverage-tool gcovr \
             -e nano --coverage-basedir infuse-sdk \
             -x=CONFIG_TEST_EXTRA_STACK_SIZE=4096 \
-            -x=CONFIG_COVERAGE_DUMP_PATH_EXCLUDE=\"*modules/crypto/mbedtls*\"
+            -x=CONFIG_COVERAGE_DUMP_PATH_EXCLUDE=\"*modules/crypto/*\"
 
       - name: Print ccache stats
         if: always()

--- a/include/infuse/algorithm_runner/algorithms/movement_threshold.h
+++ b/include/infuse/algorithm_runner/algorithms/movement_threshold.h
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: FSL-1.1-ALv2
  *
  * @details
- * Only explicitly controls @a INFUSE_STATE_DEVICE_STOPPED_MOVING and
+ * Only explicitly controls @a INFUSE_STATE_DEVICE_MOVING and
  * @a INFUSE_STATE_DEVICE_STARTED_MOVING, not the corresponding
  * @a INFUSE_STATE_DEVICE_STATIONARY and @a INFUSE_STATE_DEVICE_STOPPED_MOVING
  * states.

--- a/kconfig/Kconfig.defaults.ztest
+++ b/kconfig/Kconfig.defaults.ztest
@@ -23,6 +23,13 @@ configdefault MBEDTLS_PSA_DRIVER_GET_ENTROPY
 
 endif # INFUSE_SECURITY || MBEDTLS
 
+# Enable semihosting for QEMU if possible when testing coverage
+configdefault SEMIHOST
+	default y if COVERAGE && QEMU_TARGET
+choice COVERAGE_DUMP_METHOD
+	default COVERAGE_SEMIHOST
+endchoice
+
 choice MBEDTLS_PSA_ITS_BACKEND
 	default MBEDTLS_PSA_ITS_BACKEND_MBEDTLS_FILE if ZTEST
 endchoice

--- a/scripts/twister_coverage.sh
+++ b/scripts/twister_coverage.sh
@@ -4,4 +4,4 @@ echo "Twister Coverage - mps2/an385"
 ./zephyr/scripts/twister -i --force-color -N -v --filter runnable \
     -p mps2/an385 --coverage -T infuse-sdk/tests --coverage-tool gcovr \
     -x=CONFIG_TEST_EXTRA_STACK_SIZE=4096 -e nano --coverage-basedir infuse-sdk \
-    -x=CONFIG_COVERAGE_DUMP_PATH_EXCLUDE=\"*modules/crypto/mbedtls*\"
+    -x=CONFIG_COVERAGE_DUMP_PATH_EXCLUDE=\"*modules/crypto/*\"

--- a/subsys/rpc/commands/bt_file_copy_coap.c
+++ b/subsys/rpc/commands/bt_file_copy_coap.c
@@ -58,6 +58,7 @@ struct net_buf *rpc_command_bt_file_copy_coap(struct net_buf *request)
 		.subscribe_data = false,
 		.subscribe_logging = false,
 	};
+	bool dfu_reboot;
 	bool already;
 
 	memcpy(coap_req.server_address, req->server_address, sizeof(req->server_address));
@@ -65,7 +66,8 @@ struct net_buf *rpc_command_bt_file_copy_coap(struct net_buf *request)
 	/* COAP file download */
 	LOG_INF("Download '%s' from %s:%d", req->resource, coap_req.server_address,
 		coap_req.server_port);
-	rc = rpc_command_coap_download_run(&coap_req, req->resource, &coap_rsp, &downloaded);
+	rc = rpc_command_coap_download_run(&coap_req, req->resource, &coap_rsp, &downloaded,
+					   &dfu_reboot);
 	rsp.resource_len = coap_rsp.resource_len;
 	rsp.resource_crc = coap_rsp.resource_crc;
 

--- a/subsys/rpc/commands/coap_download.c
+++ b/subsys/rpc/commands/coap_download.c
@@ -17,6 +17,7 @@
 #include <infuse/dfu/helpers.h>
 #include <infuse/rpc/commands.h>
 #include <infuse/rpc/types.h>
+#include <infuse/rpc/command_runner.h>
 #include <infuse/fs/kv_store.h>
 #include <infuse/security.h>
 #include <infuse/net/coap.h>
@@ -49,7 +50,8 @@ static int data_cb(uint32_t offset, const uint8_t *data, uint16_t data_len, void
 }
 
 int rpc_command_coap_download_run(struct rpc_coap_download_v2_request *req, char *resource,
-				  struct rpc_coap_download_v2_response *rsp, int *downloaded)
+				  struct rpc_coap_download_v2_response *rsp, int *downloaded,
+				  bool *dfu_reboot)
 {
 	const sec_tag_t sec_tls_tags[] = {
 		infuse_security_coap_dtls_tag(),
@@ -139,7 +141,7 @@ int rpc_command_coap_download_run(struct rpc_coap_download_v2_request *req, char
 
 download_done:
 	/* Finish file write process */
-	rc = rpc_common_file_actions_finish(&ctx, RPC_ID_COAP_DOWNLOAD, false);
+	rc = rpc_common_file_actions_finish(&ctx, false, dfu_reboot);
 	if (rc < 0) {
 		LOG_ERR("Failed to finish %d (%d)", req->action, rc);
 	}
@@ -161,6 +163,38 @@ error:
 	return rc;
 }
 
+static struct net_buf *rpc_command_coap_handle_response(struct net_buf *request,
+							struct rpc_coap_download_v2_response *rsp,
+							int rc, uint8_t action, bool dfu_reboot)
+{
+	const struct infuse_rpc_req_header *req_header = (const void *)request->data;
+	struct epacket_rx_metadata *req_meta = net_buf_user_data(request);
+	struct net_buf *response =
+		rpc_response_simple_if(req_meta->interface, rc, rsp, sizeof(*rsp));
+
+	if (!dfu_reboot) {
+		/* We're not rebooting, let the server send the response */
+		return response;
+	}
+
+	/* Queue the response before scheduling the reboot, as reboots start shutting down
+	 * networking interfaces.
+	 */
+	rpc_command_runner_early_response(req_meta, req_header->request_id, req_header->command_id,
+					  response);
+	/* Hopefully sufficient time for response to be transmitted */
+	k_sleep(K_MSEC(1000));
+#ifdef CONFIG_INFUSE_REBOOT
+	/* Schedule the reboot */
+	LOG_INF("File action complete, rebooting for DFU");
+	infuse_reboot_delayed(INFUSE_REBOOT_DFU, req_header->command_id, action, K_SECONDS(2));
+#else
+	LOG_WRN("INFUSE_REBOOT not enabled, cannot reboot");
+#endif /* CONFIG_INFUSE_REBOOT */
+	/* We sent the response, server should not send anything */
+	return NULL;
+}
+
 /* Responses are equivalent */
 BUILD_ASSERT(sizeof(struct rpc_coap_download_response) ==
 	     sizeof(struct rpc_coap_download_v2_response));
@@ -170,6 +204,7 @@ struct net_buf *rpc_command_coap_download(struct net_buf *request)
 {
 	struct rpc_coap_download_request *req = (void *)request->data;
 	struct rpc_coap_download_v2_response rsp = {0};
+	bool dfu_reboot = false;
 	int downloaded;
 	int rc;
 
@@ -187,10 +222,10 @@ struct net_buf *rpc_command_coap_download(struct net_buf *request)
 	memcpy(req_v2.server_address, req->server_address, sizeof(req_v2.server_address));
 
 	/* Run the command */
-	rc = rpc_command_coap_download_run(&req_v2, req->resource, &rsp, &downloaded);
+	rc = rpc_command_coap_download_run(&req_v2, req->resource, &rsp, &downloaded, &dfu_reboot);
 
-	/* Return the response */
-	return rpc_response_simple_req(request, rc, &rsp, sizeof(rsp));
+	/* Handle the response */
+	return rpc_command_coap_handle_response(request, &rsp, rc, req_v2.action, dfu_reboot);
 }
 #endif /* CONFIG_INFUSE_RPC_COMMAND_COAP_DOWNLOAD */
 
@@ -199,13 +234,14 @@ struct net_buf *rpc_command_coap_download_v2(struct net_buf *request)
 {
 	struct rpc_coap_download_v2_request *req = (void *)request->data;
 	struct rpc_coap_download_v2_response rsp = {0};
+	bool dfu_reboot = false;
 	int downloaded;
 	int rc;
 
 	/* Run the command */
-	rc = rpc_command_coap_download_run(req, req->resource, &rsp, &downloaded);
+	rc = rpc_command_coap_download_run(req, req->resource, &rsp, &downloaded, &dfu_reboot);
 
-	/* Return the response */
-	return rpc_response_simple_req(request, rc, &rsp, sizeof(rsp));
+	/* Handle the response */
+	return rpc_command_coap_handle_response(request, &rsp, rc, req->action, dfu_reboot);
 }
 #endif /* CONFIG_INFUSE_RPC_COMMAND_COAP_DOWNLOAD_V2 */

--- a/subsys/rpc/commands/common_coap.h
+++ b/subsys/rpc/commands/common_coap.h
@@ -10,4 +10,5 @@
 
 /* Implementation of COAP_DOWNLOAD */
 int rpc_command_coap_download_run(struct rpc_coap_download_v2_request *req, char *resource,
-				  struct rpc_coap_download_v2_response *rsp, int *downloaded);
+				  struct rpc_coap_download_v2_response *rsp, int *downloaded,
+				  bool *dfu_reboot);

--- a/subsys/rpc/commands/common_file_actions.c
+++ b/subsys/rpc/commands/common_file_actions.c
@@ -401,13 +401,12 @@ cleanup:
 
 #endif /* SUPPORT_APP_CPATCH */
 
-int rpc_common_file_actions_finish(struct rpc_common_file_actions_ctx *ctx, uint16_t rpc_id,
-				   bool defer_long)
+int rpc_common_file_actions_finish(struct rpc_common_file_actions_ctx *ctx, bool defer_long,
+				   bool *dfu_reboot)
 {
 	__maybe_unused uint32_t data_crc;
 	size_t mem_size;
 	uint8_t *mem;
-	bool reboot = false;
 	int rc = 0;
 
 	/* Temporary memory buffer */
@@ -507,10 +506,10 @@ int rpc_common_file_actions_finish(struct rpc_common_file_actions_ctx *ctx, uint
 		/* Close the flash area */
 		pm_flash_area_close(ctx->fa);
 #if defined(CONFIG_MCUBOOT_UPGRADE_ONLY_AUTOMATIC)
-		reboot = true;
+		*dfu_reboot = true;
 #elif defined(CONFIG_MCUBOOT_IMG_MANAGER)
 		if (boot_request_upgrade_multi(0, BOOT_UPGRADE_TEST) == 0) {
-			reboot = true;
+			*dfu_reboot = true;
 		}
 #else
 		LOG_WRN("Cannot request application upgrade");
@@ -530,7 +529,7 @@ int rpc_common_file_actions_finish(struct rpc_common_file_actions_ctx *ctx, uint
 		rc = bt_controller_manager_file_write_finish(ctx->client_ctx, &ctx->received,
 							     &ctx->crc);
 		if (rc == 0) {
-			reboot = true;
+			*dfu_reboot = true;
 		}
 		break;
 #endif /* CONFIG_BT_CONTROLLER_MANAGER */
@@ -541,7 +540,7 @@ int rpc_common_file_actions_finish(struct rpc_common_file_actions_ctx *ctx, uint
 			rc = -EIO;
 		}
 		if (rc == 0) {
-			reboot = true;
+			*dfu_reboot = true;
 		}
 		break;
 #endif /* CONFIG_NRF_MODEM_LIB */
@@ -549,27 +548,17 @@ int rpc_common_file_actions_finish(struct rpc_common_file_actions_ctx *ctx, uint
 		break;
 	}
 
-	if (reboot) {
-#ifdef CONFIG_INFUSE_REBOOT
-		/* Schedule the reboot in a few seconds time */
-		LOG_INF("File action complete, rebooting for DFU");
-		infuse_reboot_delayed(INFUSE_REBOOT_DFU, rpc_id, ctx->action, K_SECONDS(2));
-#else
-		LOG_WRN("INFUSE_REBOOT not enabled, cannot reboot");
-#endif /* CONFIG_INFUSE_REBOOT */
-	}
-
 	return rc;
 }
 
-int rpc_common_file_actions_deferred(struct rpc_common_file_actions_ctx *ctx, uint16_t rpc_id)
+int rpc_common_file_actions_deferred(struct rpc_common_file_actions_ctx *ctx, bool *dfu_reboot)
 {
 	/* Deferred write actions */
 	switch (ctx->action) {
 #ifdef SUPPORT_APP_CPATCH
 	case RPC_ENUM_FILE_ACTION_APP_CPATCH:
 		/* Run the normal finish logic */
-		return rpc_common_file_actions_finish(ctx, rpc_id, false);
+		return rpc_common_file_actions_finish(ctx, false, dfu_reboot);
 #endif /* SUPPORT_APP_CPATCH */
 	default:
 		return 0;

--- a/subsys/rpc/commands/common_file_actions.h
+++ b/subsys/rpc/commands/common_file_actions.h
@@ -34,9 +34,9 @@ int rpc_common_file_actions_start(struct rpc_common_file_actions_ctx *ctx,
 int rpc_common_file_actions_write(struct rpc_common_file_actions_ctx *ctx, uint32_t offset,
 				  const void *data, size_t data_len);
 
-int rpc_common_file_actions_finish(struct rpc_common_file_actions_ctx *ctx, uint16_t rpc_id,
-				   bool defer_long);
+int rpc_common_file_actions_finish(struct rpc_common_file_actions_ctx *ctx, bool defer_long,
+				   bool *dfu_reboot);
 
-int rpc_common_file_actions_deferred(struct rpc_common_file_actions_ctx *ctx, uint16_t rpc_id);
+int rpc_common_file_actions_deferred(struct rpc_common_file_actions_ctx *ctx, bool *dfu_reboot);
 
 int rpc_common_file_actions_error_cleanup(struct rpc_common_file_actions_ctx *ctx);

--- a/subsys/rpc/commands/file_write_basic.c
+++ b/subsys/rpc/commands/file_write_basic.c
@@ -125,9 +125,10 @@ write_done:
 	 * take any action (rebooting us) until the patching is actually complete.
 	 */
 	bool defer = IS_ENABLED(CONFIG_BT_CTLR_ONLY) ? false : true;
+	bool dfu_reboot = false;
 
 	/* Finish file write process, deferring long operations */
-	rc = rpc_common_file_actions_finish(&ctx, RPC_ID_FILE_WRITE_BASIC, defer);
+	rc = rpc_common_file_actions_finish(&ctx, defer, &dfu_reboot);
 	if (rc < 0) {
 		LOG_ERR("Failed to finish %d (%d)", action, rc);
 	}
@@ -143,8 +144,26 @@ write_done:
 
 	if (rc == 0) {
 		/* Perform deferred long operations */
-		(void)rpc_common_file_actions_deferred(&ctx, RPC_ID_FILE_WRITE_BASIC);
+		(void)rpc_common_file_actions_deferred(&ctx, &dfu_reboot);
 	}
+
+	if (dfu_reboot) {
+#ifdef CONFIG_INFUSE_REBOOT
+		/* The response has been queued, perform a short delay to allow the data to be sent
+		 * before infuse_reboot_delayed potentially starts shutting down interfaces.
+		 */
+		k_sleep(K_MSEC(500));
+		/* Schedule the reboot in a few seconds time */
+		LOG_INF("File action complete, rebooting for DFU");
+		infuse_reboot_delayed(INFUSE_REBOOT_DFU, RPC_ID_FILE_WRITE_BASIC, action,
+				      K_SECONDS(2));
+#else
+		LOG_WRN("INFUSE_REBOOT not enabled, cannot reboot");
+#endif /* CONFIG_INFUSE_REBOOT */
+
+		/* Give a  */
+	}
+
 	return NULL;
 error:
 	/* Cleanup resources */

--- a/subsys/rpc/commands/reboot.c
+++ b/subsys/rpc/commands/reboot.c
@@ -10,6 +10,7 @@
 #include <zephyr/logging/log.h>
 
 #include <infuse/rpc/commands.h>
+#include <infuse/rpc/command_runner.h>
 #include <infuse/rpc/types.h>
 #include <infuse/reboot.h>
 
@@ -17,18 +18,25 @@ LOG_MODULE_DECLARE(rpc_server, CONFIG_INFUSE_RPC_LOG_LEVEL);
 
 struct net_buf *rpc_command_reboot(struct net_buf *request)
 {
+	struct epacket_rx_metadata *req_meta = net_buf_user_data(request);
 	struct rpc_reboot_request *req = (void *)request->data;
 	struct rpc_reboot_response rsp = {
 		.delay_ms = req->delay_ms ? req->delay_ms : 2000,
 	};
+	uint32_t schedule_delay_ms = MIN(rsp.delay_ms, 500);
 	struct net_buf *response;
 
 	/* Allocate the response packet */
 	response = rpc_response_simple_req(request, 0, &rsp, sizeof(rsp));
+	/* Queue the response immediately */
+	rpc_command_runner_early_response(req_meta, req->header.request_id, RPC_ID_REBOOT,
+					  response);
+	LOG_INF("%s: Rebooting in %d ms", __func__, rsp.delay_ms);
+	/* Add a delay before scheduling the reboot, as it starts bringing down interfaces */
+	k_sleep(K_MSEC(schedule_delay_ms));
 	/* Schedule the reboot */
 	infuse_reboot_delayed(INFUSE_REBOOT_RPC, (uintptr_t)rpc_command_reboot, 0x00,
-			      K_MSEC(rsp.delay_ms));
-	LOG_INF("%s: Rebooting in %d ms", __func__, rsp.delay_ms);
+			      K_MSEC(rsp.delay_ms - schedule_delay_ms));
 	/* Return the response */
-	return response;
+	return NULL;
 }

--- a/west.yml
+++ b/west.yml
@@ -14,7 +14,7 @@ manifest:
 
   projects:
     - name: zephyr
-      revision: 9ccad011e30c896b5657787c96338b839bc243eb
+      revision: 6b22106d9c7292c35f8479abafa6d8a4ffe1348a
       # Limit imported repositories to reduce clone time
       import:
         name-allowlist:


### PR DESCRIPTION
Extract the DFU reboot from the common file handling back into the
individual commands. Since scheduling a reboot starts shutting down
networking interfaces, we need to send the response and add a delay
before sending the response if we want the response to be reliable.

Similar logic is added to the `reboot` RPC.