### PR TITLE
gnss: u-blox m10: configurable RF LNA mode

### DIFF
--- a/drivers/fuel_gauge/max17260.c
+++ b/drivers/fuel_gauge/max17260.c
@@ -321,7 +321,7 @@ static int max17260_init(const struct device *dev)
 	return max17260_shutdown_exit(dev);
 }
 
-static const struct fuel_gauge_driver_api max17260_api = {
+static DEVICE_API(fuel_gauge, max17260_api) = {
 	.get_property = max17260_get_prop,
 	.set_property = max17260_set_prop,
 	.get_buffer_property = NULL,

--- a/drivers/gnss/gnss_nrf9x_emul.c
+++ b/drivers/gnss/gnss_nrf9x_emul.c
@@ -193,7 +193,7 @@ static int nrf9x_gnss_init(const struct device *dev)
 	return 0;
 }
 
-const struct gnss_driver_api emul_gnss_api = {
+static DEVICE_API(gnss, emul_gnss_api) = {
 	.set_enabled_systems = emul_set_enabled_systems,
 	.get_enabled_systems = emul_get_enabled_systems,
 	.get_supported_systems = emul_get_supported_systems,

--- a/drivers/gnss/gnss_u_blox_m10_i2c.c
+++ b/drivers/gnss/gnss_u_blox_m10_i2c.c
@@ -32,6 +32,7 @@
 struct ubx_m10_i2c_config {
 	struct ubx_common_config common;
 	struct i2c_dt_spec i2c;
+	uint8_t rf_lna_mode;
 };
 
 struct ubx_m10_i2c_data {
@@ -364,6 +365,9 @@ static int ubx_m10_i2c_port_setup(const struct device *dev, bool hardware_reset)
 			     UBX_CFG_TXREADY_INTERFACE_I2C);
 	UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_TXREADY_THRESHOLD, 1);
 
+	/* Setup RF low-noise amplifier */
+	UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_HW_RF_LNA_MODE, cfg->rf_lna_mode);
+
 	/* We set the timepulse pin to use falling edges here, as the timepulse pin has a
 	 * weak pullup to VCC internally. Using the rising edge default can result in spurious
 	 * timepulse edges when the modem wakes from sleep modes:
@@ -525,6 +529,7 @@ static DEVICE_API(gnss, gnss_api) = {
 						 ubx_m10_i2c_software_resume,                      \
 						 ubx_m10_i2c_port_setup, ubx_m10_fifo_poll),       \
 		.i2c = I2C_DT_SPEC_INST_GET(inst),                                                 \
+		.rf_lna_mode = DT_INST_ENUM_IDX(inst, rf_lna_mode),                                \
 	};                                                                                         \
 	static struct ubx_m10_i2c_data ubx_m10_data_##inst;                                        \
 	PM_DEVICE_DT_INST_DEFINE(inst, ubx_common_pm_control);                                     \

--- a/drivers/gnss/gnss_u_blox_m10_i2c.c
+++ b/drivers/gnss/gnss_u_blox_m10_i2c.c
@@ -504,7 +504,7 @@ static int ubx_m10_i2c_init(const struct device *dev)
 	return ubx_common_init(dev, pipe);
 }
 
-static const struct gnss_driver_api gnss_api = {
+static DEVICE_API(gnss, gnss_api) = {
 #ifndef CONFIG_GNSS_U_BLOX_NO_API_COMPAT
 	.set_fix_rate = ubx_m10_i2c_set_fix_rate,
 	.get_fix_rate = ubx_m10_i2c_get_fix_rate,

--- a/drivers/gnss/gnss_u_blox_m8_emul.c
+++ b/drivers/gnss/gnss_u_blox_m8_emul.c
@@ -350,7 +350,7 @@ static int emul_init(const struct device *dev)
 	return pm_device_driver_init(dev, emul_pm_control);
 }
 
-const struct gnss_driver_api emul_gnss_api = {
+static DEVICE_API(gnss, emul_gnss_api) = {
 	.set_enabled_systems = emul_set_enabled_systems,
 	.get_enabled_systems = emul_get_enabled_systems,
 	.get_supported_systems = emul_get_supported_systems,

--- a/drivers/gnss/gnss_u_blox_m8_spi.c
+++ b/drivers/gnss/gnss_u_blox_m8_spi.c
@@ -492,7 +492,7 @@ static int ubx_m8_spi_init(const struct device *dev)
 	return ubx_common_init(dev, pipe);
 }
 
-static const struct gnss_driver_api gnss_api = {
+static DEVICE_API(gnss, gnss_api) = {
 #ifndef CONFIG_GNSS_U_BLOX_NO_API_COMPAT
 	.set_fix_rate = ubx_m8_spi_set_fix_rate,
 	.get_fix_rate = ubx_m8_spi_get_fix_rate,

--- a/drivers/sensor/bq25798.c
+++ b/drivers/sensor/bq25798.c
@@ -381,7 +381,7 @@ static int bq25798_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api bq25798_driver_api = {
+static DEVICE_API(sensor, bq25798_driver_api) = {
 	.sample_fetch = bq25798_sample_fetch,
 	.channel_get = bq25798_channel_get,
 };

--- a/drivers/sensor/generic_sim.c
+++ b/drivers/sensor/generic_sim.c
@@ -115,7 +115,7 @@ static int generic_sim_pm_control(const struct device *dev, enum pm_device_actio
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static const struct sensor_driver_api generic_sim_driver_api = {
+static DEVICE_API(sensor, generic_sim_driver_api) = {
 	.sample_fetch = generic_sim_sample_fetch,
 	.channel_get = generic_sim_channel_get,
 };

--- a/drivers/sensor/nrf9x_batt.c
+++ b/drivers/sensor/nrf9x_batt.c
@@ -53,7 +53,7 @@ static int nrf9x_batt_channel_get(const struct device *dev, enum sensor_channel 
 	return sensor_value_from_milli(val, data->voltage_mv);
 }
 
-static const struct sensor_driver_api nrf9x_batt_driver_api = {
+static DEVICE_API(sensor, nrf9x_batt_driver_api) = {
 	.sample_fetch = nrf9x_batt_sample_fetch,
 	.channel_get = nrf9x_batt_channel_get,
 };

--- a/drivers/sensor/nrf9x_temp.c
+++ b/drivers/sensor/nrf9x_temp.c
@@ -50,7 +50,7 @@ static int nrf9x_temp_channel_get(const struct device *dev, enum sensor_channel 
 	return 0;
 }
 
-static const struct sensor_driver_api nrf9x_temp_driver_api = {
+static DEVICE_API(sensor, nrf9x_temp_driver_api) = {
 	.sample_fetch = nrf9x_temp_sample_fetch,
 	.channel_get = nrf9x_temp_channel_get,
 };

--- a/dts/bindings/gnss/u-blox,m10-i2c.yaml
+++ b/dts/bindings/gnss/u-blox,m10-i2c.yaml
@@ -6,3 +6,17 @@ description: U-BLOX M10 GNSS Module
 compatible: "u-blox,m10-i2c"
 
 include: [i2c-device.yaml, "u-blox-common.yaml"]
+
+properties:
+  rf-lna-mode:
+    type: string
+    enum:
+      - "NORMAL"
+      - "LOWGAIN"
+      - "BYPASS"
+    default: "NORMAL"
+    description: |
+      Operating mode for the RF LNA.
+      Normal: internal LNA enabled at full gain
+      Low Gain: LNA enabled in low gain mode
+      Bypass: Bypass LNA


### PR DESCRIPTION
Make the low-noise amplifier mode configurable from devicetree. The appropriate mode depends on the hardware design, whether a passive or active antenna is connected.