### PR TITLE
rpc: commands: bt_file_copy_basic: feed RPC server watchdog

### DIFF
--- a/subsys/rpc/commands/bt_file_copy_basic.c
+++ b/subsys/rpc/commands/bt_file_copy_basic.c
@@ -158,7 +158,7 @@ int rpc_command_bt_file_copy_basic_run(struct rpc_bt_file_copy_basic_request *re
 	rpc_server_watchdog_feed();
 
 	/* Wait for initial ACK */
-	rc = rpc_client_ack_wait(&client_ctx, request_id, K_SECONDS(5));
+	rc = rpc_client_ack_wait(&client_ctx, request_id, K_SECONDS(15));
 	if (rc < 0) {
 		LOG_WRN("Initial ACK not received");
 		goto cleanup;
@@ -177,7 +177,7 @@ int rpc_command_bt_file_copy_basic_run(struct rpc_bt_file_copy_basic_request *re
 					     &load_params);
 
 	/* Wait for final RPC_RSP */
-	rc = k_sem_take(&completion_ctx.done, K_SECONDS(1));
+	rc = k_sem_take(&completion_ctx.done, K_SECONDS(2));
 	if (rc == 0) {
 		rc = completion_ctx.rc;
 	}

--- a/subsys/rpc/commands/bt_file_copy_basic.c
+++ b/subsys/rpc/commands/bt_file_copy_basic.c
@@ -47,6 +47,9 @@ static void command_data_done(const struct net_buf *buf, void *user_data)
 
 static int file_loader(void *user_data, uint32_t offset, void *data, size_t data_len)
 {
+	/* Prevent RPC server watchdog channel timing out */
+	rpc_server_watchdog_feed();
+
 #ifdef CONFIG_INFUSE_LITTLEFS
 	int rc;
 
@@ -150,6 +153,9 @@ int rpc_command_bt_file_copy_basic_run(struct rpc_bt_file_copy_basic_request *re
 	__ASSERT_NO_MSG(rc == 0);
 	load_params.user_data = (void *)fa;
 #endif
+
+	/* Feed watchdog before waiting (a potentially long time) for the first ACK */
+	rpc_server_watchdog_feed();
 
 	/* Wait for initial ACK */
 	rc = rpc_client_ack_wait(&client_ctx, request_id, K_SECONDS(5));


### PR DESCRIPTION
Feed the RPC server watchdog when copying data over Bluetooth to prevent
the software watchdog from incorrectly assuming the server is dead.
Copies sending complete firmware images can take longer than the default
watchdog period.

Increase the response timeouts for both the initial ACK and the final
response. 5 seconds can be insufficient when the remote is erasing an
entire secondary image slot, and waiting an extra 1 second at the very
end to receive the final confirmation has essentially no cost compared
to the effort of setting up the connection and transferring the file.