### PR TITLE
manifest: update zephyr fork

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -14,7 +14,7 @@ manifest:
 
   projects:
     - name: zephyr
-      revision: 20cc5ed135eeb3d62494c23feb19a381e7dc0774
+      revision: e5e7ce3a5ce0c1a7b0ebf220bb3fb4d170928dc0
       # Limit imported repositories to reduce clone time
       import:
         name-allowlist:


### PR DESCRIPTION
Update Zephyr fork to fix Kconfig dependency problems that cause a single testcase to fail in daily CI, and fix coverage path discovery for merging GCDA files generated by `COVERAGE_SEMIHOST`.