### PR TITLE
algorithms: algorithm_build.cmake: cleanup cmake

### DIFF
--- a/subsys/algorithms/algorithm_build.cmake
+++ b/subsys/algorithms/algorithm_build.cmake
@@ -64,58 +64,50 @@ function(algorithm_generate_targets
     # Import the CFLAGS and variants from the profile
     include("${PROFILE_FILE}")
 
-    # Include Directories
-    list(APPEND CFLAGS "-I${INFUSE_SDK_BASE}/include")
-    list(APPEND CFLAGS "-I${INFUSE_SDK_BASE}/generated/include")
-    list(APPEND CFLAGS "-I${ZEPHYR_BASE}/include")
-    foreach(INC_FOLDER IN LISTS INC_FOLDERS)
-      list(APPEND CFLAGS "-I${INC_FOLDER}")
-    endforeach()
-
     # Build the algorithm for each supported floating-point mode
     foreach(FP_MODE IN LISTS PROFILE_FP_MODES)
       algorithm_target_name_core(${ALG_NAME} ${PROFILE_NAME} ${FP_MODE} target_name)
       algorithm_target_dir_core(${PROFILE_NAME} ${FP_MODE} ${OUTPUT_BASE} target_folder)
-      make_directory(${target_folder})
+      set(llext_file ${target_folder}/${ALG_NAME}.llext)
+      set(stripped_file ${target_folder}/${ALG_NAME}.llext.stripped)
+      set(inc_file ${target_folder}/${ALG_NAME}.inc)
 
-      # Prepare object file list and compile commands for each source file
-      set(OBJ_FILES)
-      set(COMPILE_COMMANDS)
-
-      foreach(SRC IN LISTS SRC_FILES)
-        get_filename_component(SRC_NAME ${SRC} NAME_WE)
-        set(OBJ ${target_folder}/${SRC_NAME}.o)
-        list(APPEND OBJ_FILES ${OBJ})
-        list(APPEND COMPILE_COMMANDS
-          COMMAND ${CMAKE_C_COMPILER} ${CFLAGS} "-mfloat-abi=${FP_MODE}" -c ${SRC} -o ${OBJ}
-        )
-      endforeach()
-
-      # Link all object files into a single relocatable object
-      list(APPEND COMPILE_COMMANDS
-        COMMAND ${CMAKE_LINKER} -r ${OBJ_FILES} -o ${target_folder}/${ALG_NAME}.llext
+      set(obj_target ${target_name}_objects)
+      add_library(${obj_target} OBJECT ${SRC_FILES})
+      target_compile_options(${obj_target} PRIVATE
+        ${CFLAGS}
+        "-mfloat-abi=${FP_MODE}"
+      )
+      target_include_directories(${obj_target} PRIVATE
+        ${INFUSE_SDK_BASE}/include
+        ${INFUSE_SDK_BASE}/generated/include
+        ${ZEPHYR_BASE}/include
+        ${INC_FOLDERS}
       )
 
+      # Link all object files into a single relocatable object
       add_custom_command(
         OUTPUT
-          ${target_folder}/${ALG_NAME}.llext.stripped
-          ${target_folder}/${ALG_NAME}.llext
-          ${target_folder}/${ALG_NAME}.inc
-        ${COMPILE_COMMANDS}
+          ${stripped_file}
+          ${llext_file}
+          ${inc_file}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${target_folder}
+        COMMAND ${CMAKE_LINKER} -r $<TARGET_OBJECTS:${obj_target}> -o ${llext_file}
         # Strip unneeded sections from the object file
         COMMAND ${CMAKE_OBJCOPY} --strip-unneeded
           --remove-section .comment
           --remove-section .ARM.attributes
-          ${target_folder}/${ALG_NAME}.llext
-          ${target_folder}/${ALG_NAME}.llext.stripped
+          ${llext_file}
+          ${stripped_file}
         # Convert object file to a hex list that can be included into a C array
         COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/file2hex.py
-          --file ${target_folder}/${ALG_NAME}.llext.stripped > ${target_folder}/${ALG_NAME}.inc
+          --file ${stripped_file} > ${inc_file}
         DEPENDS
-          ${SRC_FILES}
+          ${obj_target}
+        COMMAND_EXPAND_LISTS
         COMMENT "Generating ${ALG_NAME} for configuration ${PROFILE_NAME}-${FP_MODE}"
       )
-      add_custom_target(${target_name} ALL DEPENDS ${target_folder}/${ALG_NAME}.llext.stripped)
+      add_custom_target(${target_name} ALL DEPENDS ${stripped_file})
     endforeach()
   endforeach()
 endfunction()

--- a/subsys/algorithms/algorithm_build.cmake
+++ b/subsys/algorithms/algorithm_build.cmake
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: FSL-1.1-ALv2
 
 file(GLOB PROFILE_FILES "${CMAKE_CURRENT_LIST_DIR}/profiles/profile_*.cmake")
+set(ALGORITHM_BUILD_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
 # Determine the target name for any application
 function(algorithm_target_name_core
@@ -100,11 +101,16 @@ function(algorithm_generate_targets
           ${llext_file}
           ${stripped_file}
         # Convert object file to a hex list that can be included into a C array
-        COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/file2hex.py
-          --file ${stripped_file} > ${inc_file}
+        COMMAND ${CMAKE_COMMAND}
+          -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
+          -DFILE2HEX_SCRIPT=${ZEPHYR_BASE}/scripts/build/file2hex.py
+          -DINPUT_FILE=${stripped_file}
+          -DOUTPUT_FILE=${inc_file}
+          -P ${ALGORITHM_BUILD_DIR}/file2hex.cmake
         DEPENDS
           ${obj_target}
         COMMAND_EXPAND_LISTS
+        VERBATIM
         COMMENT "Generating ${ALG_NAME} for configuration ${PROFILE_NAME}-${FP_MODE}"
       )
       add_custom_target(${target_name} ALL DEPENDS ${stripped_file})

--- a/subsys/algorithms/algorithm_build.cmake
+++ b/subsys/algorithms/algorithm_build.cmake
@@ -54,10 +54,21 @@ endfunction()
 # Generate targets to build a given algorithm for all application configurations
 function(algorithm_generate_targets
     ALG_NAME          # Name of the algorithm
-    SRC_FILES         # Source files that implement the algorithm
-    INC_FOLDERS       # Extra include folders for the algorithm
-    OUTPUT_BASE       # Base folder that algortithms are built into
     )
+
+  cmake_parse_arguments(ARG
+    ""
+    "OUTPUT_BASE"
+    "SOURCES;INCLUDES"
+    ${ARGN}
+  )
+
+  if(NOT ARG_OUTPUT_BASE)
+    message(FATAL_ERROR "algorithm_generate_targets requires OUTPUT_BASE")
+  endif()
+  if(NOT ARG_SOURCES)
+    message(FATAL_ERROR "algorithm_generate_targets requires SOURCES")
+  endif()
 
   foreach(PROFILE_FILE IN LISTS PROFILE_FILES)
     message(DEBUG "Profile file: ${PROFILE_FILE}")
@@ -68,13 +79,13 @@ function(algorithm_generate_targets
     # Build the algorithm for each supported floating-point mode
     foreach(FP_MODE IN LISTS PROFILE_FP_MODES)
       algorithm_target_name_core(${ALG_NAME} ${PROFILE_NAME} ${FP_MODE} target_name)
-      algorithm_target_dir_core(${PROFILE_NAME} ${FP_MODE} ${OUTPUT_BASE} target_folder)
+      algorithm_target_dir_core(${PROFILE_NAME} ${FP_MODE} ${ARG_OUTPUT_BASE} target_folder)
       set(llext_file ${target_folder}/${ALG_NAME}.llext)
       set(stripped_file ${target_folder}/${ALG_NAME}.llext.stripped)
       set(inc_file ${target_folder}/${ALG_NAME}.inc)
 
       set(obj_target ${target_name}_objects)
-      add_library(${obj_target} OBJECT ${SRC_FILES})
+      add_library(${obj_target} OBJECT ${ARG_SOURCES})
       target_compile_options(${obj_target} PRIVATE
         ${CFLAGS}
         "-mfloat-abi=${FP_MODE}"
@@ -83,7 +94,7 @@ function(algorithm_generate_targets
         ${INFUSE_SDK_BASE}/include
         ${INFUSE_SDK_BASE}/generated/include
         ${ZEPHYR_BASE}/include
-        ${INC_FOLDERS}
+        ${ARG_INCLUDES}
       )
 
       # Link all object files into a single relocatable object

--- a/subsys/algorithms/file2hex.cmake
+++ b/subsys/algorithms/file2hex.cmake
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: FSL-1.1-ALv2
+
+execute_process(
+  COMMAND ${PYTHON_EXECUTABLE} ${FILE2HEX_SCRIPT} --file ${INPUT_FILE}
+  OUTPUT_FILE ${OUTPUT_FILE}
+  COMMAND_ERROR_IS_FATAL ANY
+)

--- a/subsys/algorithms/profiles/base.cmake
+++ b/subsys/algorithms/profiles/base.cmake
@@ -9,8 +9,6 @@ set(CFLAGS
   "-DLL_EXTENSION_BUILD"
   "-nodefaultlibs"
   "-std=c99"
-  # Compile only, no linking
-  "-c"
   # Stdlib
   "-specs=picolibc.specs"
   "-fno-common"

--- a/tests/subsys/algorithms/build_system/CMakeLists.txt
+++ b/tests/subsys/algorithms/build_system/CMakeLists.txt
@@ -19,8 +19,11 @@ if(CONFIG_TEST_ALGORITHM_BUILD_LLEXT)
   include(${INFUSE_SDK_BASE}/subsys/algorithms/algorithm_build.cmake)
   set(algorithm_name test_algorithm)
   set(algorithm_base_dir "${PROJECT_BINARY_DIR}/llext")
-  # Leave source and includes within quotes to prevent unpacking lists.
-  algorithm_generate_targets(${algorithm_name} "${algorithm_src}" "${algorithm_inc}" ${algorithm_base_dir})
+  algorithm_generate_targets(${algorithm_name}
+    SOURCES ${algorithm_src}
+    INCLUDES ${algorithm_inc}
+    OUTPUT_BASE ${algorithm_base_dir}
+  )
   # Add algorithm as application dependency
   algorithm_target_name(${algorithm_name} algorithm_target)
   add_dependencies(app ${algorithm_target})


### PR DESCRIPTION
Cleanup cmake logic by creating a dedicated target for the object files and using functions like `target_compile_options` instead of manually constructing compiler commands.

Accept list variables for the sources and include paths in `algorithm_generate_targets` natively, instead of the caller needing to do string quoting workarounds.