### PR TITLE
rpc: commands: bt_file_copy_basic: handle early response

### DIFF
--- a/subsys/rpc/commands/bt_file_copy_basic.c
+++ b/subsys/rpc/commands/bt_file_copy_basic.c
@@ -164,6 +164,13 @@ int rpc_command_bt_file_copy_basic_run(struct rpc_bt_file_copy_basic_request *re
 		goto cleanup;
 	}
 
+	/* Check for early termination */
+	if (k_sem_take(&completion_ctx.done, K_NO_WAIT) == 0) {
+		/* Command terminated before first ACK */
+		rc = completion_ctx.rc;
+		goto cleanup;
+	}
+
 	/* Reduce timeout value for bulk data transfer */
 	rc = rpc_client_update_response_timeout(&client_ctx, request_id, K_SECONDS(1));
 	if (rc < 0) {


### PR DESCRIPTION
If the `RPC_ID_FILE_WRITE_BASIC` command returns before the first ACK, propogate the response back to the caller, instead of returning `-EINVAL` because `rpc_client_update_response_timeout` fails.