### PR TITLE
common_boot: add locally managed ID warning

### DIFF
--- a/lib/common_boot.c
+++ b/lib/common_boot.c
@@ -291,6 +291,20 @@ static int infuse_common_boot(void)
 #endif /* CONFIG_BT_CONTROLLER_MANAGE*/
 #endif /* CONFIG_BT */
 
+	if ((device_id & INFUSE_LOCALLY_MANAGED_PREFIX) == INFUSE_LOCALLY_MANAGED_PREFIX) {
+		/* Authenticated commands can only be generated through the shared secret
+		 * derived from the Infuse-IoT Cloud keypair. If the device is not provisioned
+		 * in Infuse-IoT Cloud, it has no way to authenticate the provenance of the
+		 * public key and will refuse to generate the secret. This prevents most
+		 * management functionality from operating, such as RPCs and anything built
+		 * on top of that (KV Sync, Logger Download, etc).
+		 * An unprovisioned device is only useful for initial evaluation without a
+		 * cloud account, where data authenticated to the network level can be observed
+		 * over Bluetooth advertising.
+		 */
+		LOG_WRN("Device is unprovisioned (Locally managed ID), functionality restricted");
+	}
+
 	LOG_INF("\tVersion: %d.%d.%d+%08x", v.major, v.minor, v.revision, v.build_num);
 	LOG_INF("\t Device: %016llx", device_id);
 	LOG_INF("\t  Board: %s", CONFIG_BOARD_TARGET);

--- a/lib/security/security.c
+++ b/lib/security/security.c
@@ -204,8 +204,8 @@ static void derive_shared_secret(psa_key_id_t root_key_id, const uint8_t public_
 				 struct infuse_key_info *key_info,
 				 mbedtls_svc_key_id_t shared_secret_storage_id)
 {
+	psa_key_attributes_t key_attributes = PSA_KEY_ATTRIBUTES_INIT;
 	uint8_t __maybe_unused shared_secret[32];
-	psa_key_attributes_t key_attributes;
 	size_t __maybe_unused olen;
 	psa_status_t status;
 	psa_key_id_t key_id;

--- a/lib/security/security.c
+++ b/lib/security/security.c
@@ -162,12 +162,12 @@ static psa_key_id_t generate_root_ecc_key_pair(void)
 		key_id = INFUSE_ROOT_ECC_KEY_ID;
 	} else {
 		LOG_DBG("Generating root identity");
-#ifdef ITS_AVAILABLE
 		/* Remove any existing root/derived keys */
-		(void)psa_its_remove(INFUSE_ROOT_ECC_KEY_ID);
+		(void)psa_destroy_key(INFUSE_ROOT_ECC_KEY_ID);
+		(void)psa_destroy_key(INFUSE_ROOT_ECC_SHARED_SECRET_KEY_ID);
+		(void)psa_destroy_key(INFUSE_ROOT_ECC_SECONDARY_SHARED_SECRET_KEY_ID);
+#ifdef ITS_AVAILABLE
 		(void)psa_its_remove(INFUSE_ROOT_ECC_PUBLIC_KEY_ID);
-		(void)psa_its_remove(INFUSE_ROOT_ECC_SHARED_SECRET_KEY_ID);
-		(void)psa_its_remove(INFUSE_ROOT_ECC_SECONDARY_SHARED_SECRET_KEY_ID);
 #endif /* ITS_AVAILABLE */
 #ifdef CONFIG_MODEM_KEY_MGMT
 		/* COAP PSK is also a derived key */
@@ -545,19 +545,12 @@ int infuse_security_init(void)
 
 int infuse_security_device_root_reset(void)
 {
-#ifdef ITS_AVAILABLE
 	psa_status_t status;
 
-	/* Delete the root keypair, `infuse_security_init` takes care of deleting all
-	 * cached persistent keys when it runs
-	 */
-	status = psa_its_remove(INFUSE_ROOT_ECC_KEY_ID);
+	status = psa_destroy_key(INFUSE_ROOT_ECC_KEY_ID);
 	if (status != PSA_SUCCESS) {
 		return -EIO;
 	}
-#else
-	/* Root keypair is not saved persistently  */
-#endif
 	return 0;
 }
 
@@ -725,21 +718,16 @@ psa_key_id_t infuse_security_secondary_device_sign_key(void)
 
 int infuse_security_secondary_device_key_reset(void)
 {
-#ifdef ITS_AVAILABLE
 	psa_status_t status;
 
-	status = psa_its_remove(INFUSE_ROOT_ECC_SECONDARY_SHARED_SECRET_KEY_ID);
+	status = psa_destroy_key(INFUSE_ROOT_ECC_SECONDARY_SHARED_SECRET_KEY_ID);
 	if (status == PSA_SUCCESS) {
 		return 0;
-	} else if (status == PSA_ERROR_DOES_NOT_EXIST) {
+	} else if (status == PSA_ERROR_INVALID_HANDLE) {
 		return -ENOENT;
 	} else {
 		return -EIO;
 	}
-#else
-	/* No cached information to delete */
-	return 0;
-#endif /* ITS_AVAILABLE */
 }
 
 #endif /* CONFIG_INFUSE_SECURITY_SECONDARY_REMOTE_ENABLE */


### PR DESCRIPTION
Add a warning output on boot if a locally managed device ID is found, which notifies the user that Infuse-IoT cloud does not know about this device, and cannot be used to run authenticated commands like RPCs etc.

Includes minor API usage updates to the security module.