### PR TITLE
dts: nordic: modem_shmem: fix application offfset

### DIFF
--- a/dts/common/nordic/modem_shmem.dtsi
+++ b/dts/common/nordic/modem_shmem.dtsi
@@ -52,9 +52,9 @@
 			};
 		};
 
-		sram0_ns_app: sram0_ns@6000 {
+		sram0_ns_app: sram0_ns@4800 {
 			/* Non-Secure application memory */
-			reg = <0x6000 DT_SIZE_K(174)>;
+			reg = <0x4800 DT_SIZE_K(174)>;
 		};
 	};
 };


### PR DESCRIPTION
Update the application SRAM offset to align with memory shifting for NCS v3.4.