### PR TITLE
 samples: nrf91x1_emc_shell: fix twister failures

### DIFF
--- a/samples/nrf91x1_emc_shell/sample.yaml
+++ b/samples/nrf91x1_emc_shell/sample.yaml
@@ -3,7 +3,10 @@ sample:
   name: nRF91x1 LTE modem EMC
 common:
   build_only: true
-  filter: CONFIG_SOC_NRF9120 and CONFIG_BUILD_WITH_TFM and dt_chosen_enabled("zephyr,shell-uart")
+  socs_allow:
+    - nrf9151
+    - nrf9161
+  filter: CONFIG_BUILD_WITH_TFM and dt_chosen_enabled("zephyr,shell-uart")
   integration_platforms:
     - nrf9161dk/nrf9161/ns
     - nrf9151dk/nrf9151/ns

--- a/scripts/examples/cpatch_demo.sh
+++ b/scripts/examples/cpatch_demo.sh
@@ -31,7 +31,6 @@ west release-build -r $RELEASE_FILE --skip-git
 
 if [ "$#" -eq 2 ]; then
     # Revert to original commit
-    START_COMMIT=`git -C $APP_DIR rev-parse HEAD`
     echo "Checking out: $START_COMMIT"
     git -C $APP_DIR checkout $START_COMMIT &> /dev/null
     west update > /dev/null

--- a/west.yml
+++ b/west.yml
@@ -16,7 +16,7 @@ manifest:
 
   projects:
     - name: zephyr
-      revision: 92e97b3f42b59c633c30a476659043d92cf79fd0
+      revision: 9bb2e5b22dc18c6a7663075c305aa335fd959e46
       # Limit imported repositories to reduce clone time
       import:
         name-allowlist:


### PR DESCRIPTION
Fix twister failures by filtering incompible boards at the SoC level rather than relying on post cmake Kconfig filters.