### PR TITLE
manifest: update zephyr fork

### DIFF
--- a/boards/embeint/auroch/auroch_nrf9151_common.dtsi
+++ b/boards/embeint/auroch/auroch_nrf9151_common.dtsi
@@ -57,7 +57,7 @@
 		gnss = &max_m10;
 		watchdog0 = &wdt0;
 		environmental0 = &sht4x;
-		environmental1 = &lps22hh;
+		environmental1 = &lps22hx;
 	};
 };
 
@@ -149,8 +149,8 @@
 		repeatability = <2>;
 	};
 
-	lps22hh: lps22hh@5c {
-		compatible = "st,lps22hh";
+	lps22hx: lps22hx@5c {
+		compatible = "st,lps22hx";
 		status = "okay";
 		reg = <0x5c>;
 		odr = <LPS22HH_DT_ODR_POWER_DOWN>;

--- a/boards/embeint/kudu/kudu_cpuapp_common.dtsi
+++ b/boards/embeint/kudu/kudu_cpuapp_common.dtsi
@@ -54,7 +54,7 @@
 		watchdog0 = &wdt31;
 		fuel-gauge0 = &fuel_gauge;
 		environmental0 = &sht4x;
-		environmental1 = &lps22hh;
+		environmental1 = &lps22hx;
 		imu0 = &lsm6dsv;
 		modem = &telit_le910c1;
 		gnss = &telit_le910c1_gnss;
@@ -212,8 +212,8 @@
 		repeatability = <2>;
 	};
 
-	lps22hh: lps22hh@5d {
-		compatible = "st,lps22hh";
+	lps22hx: lps22hx@5d {
+		compatible = "st,lps22hx";
 		status = "okay";
 		reg = <0x5d>;
 		odr = <LPS22HH_DT_ODR_POWER_DOWN>;

--- a/boards/embeint/tauro2/tauro2_nrf9151_common.dtsi
+++ b/boards/embeint/tauro2/tauro2_nrf9151_common.dtsi
@@ -49,7 +49,7 @@
 		gnss = &max_m10;
 		watchdog0 = &wdt0;
 		environmental0 = &sht4x;
-		environmental1 = &lps22hh;
+		environmental1 = &lps22hx;
 	};
 };
 
@@ -194,8 +194,8 @@
 		repeatability = <2>;
 	};
 
-	lps22hh: lps22hh@5c {
-		compatible = "st,lps22hh";
+	lps22hx: lps22hx@5c {
+		compatible = "st,lps22hx";
 		status = "okay";
 		reg = <0x5c>;
 		odr = <LPS22HH_DT_ODR_POWER_DOWN>;

--- a/snippets/infuse/boards/tauro2_nrf9151_ns.overlay
+++ b/snippets/infuse/boards/tauro2_nrf9151_ns.overlay
@@ -134,7 +134,7 @@
 	zephyr,pm-device-runtime-auto;
 };
 
-&lps22hh {
+&lps22hx {
 	zephyr,pm-device-runtime-auto;
 };
 

--- a/west.yml
+++ b/west.yml
@@ -16,7 +16,7 @@ manifest:
 
   projects:
     - name: zephyr
-      revision: 9bb2e5b22dc18c6a7663075c305aa335fd959e46
+      revision: fb3e947bce5a376a8b825cca4ee86ec964fe4317
       # Limit imported repositories to reduce clone time
       import:
         name-allowlist:


### PR DESCRIPTION
Update zephyr fork with `zephyr,fuel-gauge-composite` charging improvements and the ability to support both LPS22HH and LPS22HB pressure sensors in a single driver and application image.