### PR TITLE
lib: modem_monitor: don't proactively clear parameters

### DIFF
--- a/lib/modem_monitor/modem_nrf9x/CMakeLists.txt
+++ b/lib/modem_monitor/modem_nrf9x/CMakeLists.txt
@@ -1,13 +1,13 @@
 # Nordic LTE modem library integration
 
-infuse_sources(nrf_modem_monitor.c)
+zephyr_library_named(infuse_modem_nrf9x)
+
+zephyr_library_sources(nrf_modem_monitor.c)
 
 if(CONFIG_INFUSE_NRF_MODEM_LIB_SIM)
-  # ${NRFXLIB_DIR} is unavailable due to the cmake evaluation order
-  # This could be resolved with `depends: nrfxlib` in module.yml, but this causes other
-  # Kconfig priority issues.
-  zephyr_include_directories(${INFUSE_DIR}/../modules/nrfconnect/nrfxlib/nrf_modem/include)
-  infuse_sources(nrf_modem_lib_sim.c)
+  # Not scoped to the library, as tests may want to include "nrf_modem.h"
+  zephyr_include_directories(${ZEPHYR_NRFXLIB_MODULE_DIR}/nrf_modem/include)
+  zephyr_library_sources(nrf_modem_lib_sim.c)
 
   zephyr_linker_sources(RODATA nrf_modem_lib.ld)
 endif()

--- a/lib/modem_monitor/modem_nrf9x/CMakeLists.txt
+++ b/lib/modem_monitor/modem_nrf9x/CMakeLists.txt
@@ -2,6 +2,12 @@
 
 zephyr_library_named(infuse_modem_nrf9x)
 
+if(CONFIG_LTE_LC_PSM_MODULE)
+  target_include_directories(
+    infuse_modem_nrf9x PRIVATE ${ZEPHYR_NRF_MODULE_DIR}/lib/lte_link_control/include
+  )
+endif()
+
 zephyr_library_sources(nrf_modem_monitor.c)
 
 if(CONFIG_INFUSE_NRF_MODEM_LIB_SIM)

--- a/lib/modem_monitor/modem_nrf9x/nrf_modem_monitor.c
+++ b/lib/modem_monitor/modem_nrf9x/nrf_modem_monitor.c
@@ -32,6 +32,10 @@
 #include <modem/modem_info.h>
 #include <nrf_modem_at.h>
 
+#ifdef CONFIG_LTE_LC_PSM_MODULE
+#include "modules/psm.h"
+#endif /* CONFIG_LTE_LC_PSM_MODULE */
+
 #include "../modem_monitor.h"
 
 LOG_MODULE_DECLARE(modem_monitor, CONFIG_INFUSE_MODEM_MONITOR_LOG_LEVEL);
@@ -45,6 +49,18 @@ LOG_MODULE_DECLARE(modem_monitor, CONFIG_INFUSE_MODEM_MONITOR_LOG_LEVEL);
 	 : IS_ENABLED(CONFIG_LTE_NETWORK_MODE_LTE_M_NBIOT)     ? LTE_LC_SYSTEM_MODE_LTEM_NBIOT     \
 	 : IS_ENABLED(CONFIG_LTE_NETWORK_MODE_LTE_M_NBIOT_GPS) ? LTE_LC_SYSTEM_MODE_LTEM_NBIOT_GPS \
 							       : LTE_LC_SYSTEM_MODE_DEFAULT)
+
+#ifdef CONFIG_LTE_LC_PSM_MODULE
+#define XMONITOR_PSM_SCANF_FORMAT                                                                  \
+	"%*d,"    /* <rsrp>: ignored */                                                            \
+	"%*d,"    /* <snr>: ignored */                                                             \
+	"%*[^,]," /* <NW-provided_eDRX_value>: ignored */                                          \
+	"\"%8[01]\","                                                                              \
+	"\"%8[01]\","                                                                              \
+	"\"%8[01]\""
+#else
+#define XMONITOR_PSM_SCANF_FORMAT
+#endif /* CONFIG_LTE_LC_PSM_MODULE */
 
 enum {
 	FLAGS_MODEM_SLEEPING = 0,
@@ -132,6 +148,12 @@ static void network_info_update(struct k_work *work)
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	static bool sim_card_queried;
 	char plmn[9] = {0};
+#ifdef CONFIG_LTE_LC_PSM_MODULE
+	char psm_active_time_str[9] = {0};
+	char psm_tau_ext_str[9] = {0};
+	char psm_tau_legacy_str[9] = {0};
+	struct lte_lc_psm_cfg psm_cfg;
+#endif /* CONFIG_LTE_LC_PSM_MODULE */
 	int rc;
 
 	/* This work is not time critical, run it later if the PDN connection is in progress */
@@ -197,11 +219,16 @@ static void network_info_update(struct k_work *work)
 				"%*[^,],"      /* <cell_id>: ignored */
 				"%" SCNu16 "," /* <phys_cell_id> */
 				"%" SCNu32 "," /* <EARFCN> */
-				,
+				XMONITOR_PSM_SCANF_FORMAT,
 				plmn, &monitor.network_state.band,
 				&monitor.network_state.cell.phys_cell_id,
+#ifdef CONFIG_LTE_LC_PSM_MODULE
+				&monitor.network_state.cell.earfcn, psm_active_time_str,
+				psm_tau_ext_str, psm_tau_legacy_str);
+#else
 				&monitor.network_state.cell.earfcn);
-	if (rc == 4) {
+#endif /* CONFIG_LTE_LC_PSM_MODULE */
+	if (rc >= 4) {
 		/* Parse MCC and MNC. The PLMN string is a 5 or 6 digit number surrounded by quotes.
 		 * The first 3 numeric characters are the MCC (Mobile Country Code).
 		 * The next 2 or 3 numeric characters are the MNC (Mobile Network Code).
@@ -217,6 +244,17 @@ static void network_info_update(struct k_work *work)
 		infuse_work_reschedule(dwork, K_SECONDS(1));
 		return;
 	}
+
+#ifdef CONFIG_LTE_LC_PSM_MODULE
+	if (rc == 7) {
+		/* Use the existing Nordic internal parsing logic */
+		rc = psm_parse(psm_active_time_str, psm_tau_ext_str, psm_tau_legacy_str, &psm_cfg);
+		if (rc == 0) {
+			monitor.network_state.psm_cfg.tau = psm_cfg.tau;
+			monitor.network_state.psm_cfg.active_time = psm_cfg.active_time;
+		}
+	}
+#endif /* CONFIG_LTE_LC_PSM_MODULE */
 
 state_logging:
 #ifdef CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG

--- a/lib/modem_monitor/modem_nrf9x/nrf_modem_monitor.c
+++ b/lib/modem_monitor/modem_nrf9x/nrf_modem_monitor.c
@@ -197,12 +197,6 @@ static void network_info_update(struct k_work *work)
 
 		monitor.network_state.cell.id = id;
 		monitor.network_state.cell.tac = tac;
-		monitor.network_state.psm_cfg.tau = -1;
-		monitor.network_state.psm_cfg.active_time = -1;
-		monitor.network_state.edrx_cfg.edrx = -1.0f;
-		monitor.network_state.edrx_cfg.ptw = -1.0f;
-		monitor.network_state.as_rai = UINT8_MAX;
-		monitor.network_state.cp_rai = UINT8_MAX;
 		goto state_logging;
 	}
 
@@ -387,9 +381,6 @@ static void lte_reg_handler(const struct lte_lc_evt *const evt)
 		/* Reset cached signal strength */
 		monitor.rsrp_cached = INT16_MIN;
 		monitor.rsrq_cached = INT8_MIN;
-		/* RAI support unknown */
-		monitor.network_state.as_rai = UINT8_MAX;
-		monitor.network_state.cp_rai = UINT8_MAX;
 		/* Set cell connected flag */
 		atomic_set_bit_to(&monitor.flags, FLAGS_CELL_CONNECTED,
 				  evt->cell.id <= LTE_LC_CELL_EUTRAN_ID_MAX);

--- a/subsys/rpc/commands/lte_state.c
+++ b/subsys/rpc/commands/lte_state.c
@@ -50,7 +50,7 @@ static void lte_modem_lte_state(struct rpc_struct_lte_state_v2 *lte)
 	lte->cp_rai = state.cp_rai;
 
 	/* Current signal state */
-	(void)lte_modem_monitor_signal_quality(&rsrp, &rsrq, false);
+	(void)lte_modem_monitor_signal_quality(&rsrp, &rsrq, true);
 	lte->rsrp = rsrp;
 	lte->rsrq = rsrq;
 }

--- a/tests/net/nrf_modem_lib/src/main.c
+++ b/tests/net/nrf_modem_lib/src/main.c
@@ -289,6 +289,21 @@ ZTEST(infuse_nrf_modem_monitor, test_integration)
 	zassert_equal(-1.0f, net_state.edrx_cfg.edrx);
 	zassert_equal(-1.0f, net_state.edrx_cfg.ptw);
 
+	/* Not registered invalidates PSM, but re-registration without CEREG PSM fields recovers */
+	nrf_modem_lib_sim_send_at("+CEREG: 0\r\n");
+	k_sleep(K_SECONDS(1));
+	lte_modem_monitor_network_state(&net_state);
+	zassert_equal(CELLULAR_REGISTRATION_NOT_REGISTERED, net_state.nw_reg_status);
+	zassert_equal(-1, net_state.psm_cfg.active_time);
+	zassert_equal(-1, net_state.psm_cfg.tau);
+
+	nrf_modem_lib_sim_send_at("+CEREG: 5,\"702A\",\"08C3BD0C\",7\r\n");
+	k_sleep(K_SECONDS(1));
+	lte_modem_monitor_network_state(&net_state);
+	zassert_equal(CELLULAR_REGISTRATION_REGISTERED_ROAMING, net_state.nw_reg_status);
+	zassert_equal(16, net_state.psm_cfg.active_time);
+	zassert_equal(46800, net_state.psm_cfg.tau);
+
 #ifdef CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG
 	k_sleep(K_MSEC(10));
 	tdf_data_logger_flush(TDF_DATA_LOGGER_SERIAL);


### PR DESCRIPTION
Don't proactively clear the PSM, EDRX and RAI settings when the registration state changes, wait for the events to be generated by the Nordic library integration in response to AT events.

While this may lead to stale values when not actively registered, it also prevents invalid values from persisting when registered, which is more important.