### PR TITLE
task_runner: schedule: explicit "never valid" enum

### DIFF
--- a/include/infuse/task_runner/schedule.h
+++ b/include/infuse/task_runner/schedule.h
@@ -31,6 +31,8 @@ extern "C" {
 enum task_runner_valid_type {
 	/** Do not update definition from KV store */
 	TASK_LOCKED = 0x80,
+	/** Task is never valid */
+	TASK_VALID_NEVER = 0,
 	/** Task is always valid */
 	TASK_VALID_ALWAYS = 1,
 	/** Task is only valid when @ref INFUSE_STATE_APPLICATION_ACTIVE is set */

--- a/subsys/task_runner/schedule.c
+++ b/subsys/task_runner/schedule.c
@@ -58,9 +58,6 @@ bool task_schedule_validate(const struct task_schedule *schedule)
 {
 	uint8_t validity_masked = schedule->validity & _TASK_VALID_MASK;
 
-	if (validity_masked == 0) {
-		return false;
-	}
 	if (validity_masked >= _TASK_VALID_END) {
 		return false;
 	}
@@ -121,6 +118,9 @@ bool task_schedule_should_start(const struct task_schedule *schedule,
 	}
 
 	/* Valdity based on application state */
+	if (validity_masked == TASK_VALID_NEVER) {
+		return false;
+	}
 	if ((validity_masked == TASK_VALID_ACTIVE) && !is_active) {
 		return false;
 	}
@@ -195,6 +195,9 @@ bool task_schedule_should_terminate(const struct task_schedule *schedule,
 	}
 
 	/* Valdity based on application state */
+	if (validity_masked == TASK_VALID_NEVER) {
+		return true;
+	}
 	if ((validity_masked == TASK_VALID_ACTIVE) && !is_active) {
 		return true;
 	}

--- a/tests/subsys/task_runner/schedules/src/main.c
+++ b/tests/subsys/task_runner/schedules/src/main.c
@@ -37,7 +37,6 @@ ZTEST(task_runner_schedules, test_schedules_states_define)
 
 ZTEST(task_runner_schedules, test_validate_schedules)
 {
-	struct task_schedule invalid1 = {0};
 	struct task_schedule invalid2 = {
 		.validity = _TASK_VALID_END,
 	};
@@ -114,7 +113,6 @@ ZTEST(task_runner_schedules, test_validate_schedules)
 		.periodicity.lockout_dynamic_battery.battery_min = 40,
 	};
 
-	zassert_false(task_schedule_validate(&invalid1));
 	zassert_false(task_schedule_validate(&invalid2));
 	zassert_false(task_schedule_validate(&invalid3));
 	zassert_false(task_schedule_validate(&invalid4));
@@ -129,6 +127,26 @@ ZTEST(task_runner_schedules, test_validate_schedules)
 	zassert_false(task_schedule_validate(&invalid13));
 	zassert_false(task_schedule_validate(&invalid14));
 	zassert_false(task_schedule_validate(&invalid15));
+}
+
+ZTEST(task_runner_schedules, test_never_schedule)
+{
+	INFUSE_STATES_ARRAY(app_states) = {0};
+	struct task_schedule schedule = {
+		.validity = TASK_VALID_NEVER,
+	};
+	struct task_schedule_state state = {0};
+
+	zassert_true(task_schedule_validate(&schedule));
+
+	/* Should never start and always stop */
+	for (int i = 0; i < 100; i++) {
+		zassert_false(task_schedule_should_start(&schedule, &state, app_states, 50 + i,
+							 150 + i, 100));
+		zassert_true(task_schedule_should_terminate(&schedule, &state, app_states, 30 + i,
+							    100 + i, 100));
+		state.runtime++;
+	}
 }
 
 ZTEST(task_runner_schedules, test_empty_schedule)

--- a/tests/subsys/task_runner/schedules_kv/src/main.c
+++ b/tests/subsys/task_runner/schedules_kv/src/main.c
@@ -49,7 +49,9 @@ ZTEST(task_runner_schedules_kv, test_schedules_kv_states_define)
 ZTEST(task_runner_schedules_kv, test_schedules_kv_invalid_not_written)
 {
 	struct task_schedule schedules[2] = {
-		{0},
+		{
+			.validity = _TASK_VALID_END,
+		},
 		{
 			.validity = TASK_VALID_ALWAYS,
 			.periodicity_type = TASK_PERIODICITY_FIXED,


### PR DESCRIPTION
Make the schedule "never valid" enumeration value a valid schedule that never runs, instead of an invalid schedule.