### PR TITLE
task_runner: tasks: gnss_ubx: improve PSMCT handling

### DIFF
--- a/drivers/gnss/gnss_u_blox_m10_i2c.c
+++ b/drivers/gnss/gnss_u_blox_m10_i2c.c
@@ -490,6 +490,15 @@ static void ubx_m10_fifo_poll(const struct device *dev)
 	k_work_reschedule(&data->i2c_backend.common.fifo_read, K_NO_WAIT);
 }
 
+static void ubx_m10_mon_rxr(const struct device *dev, bool awake)
+{
+	struct ubx_m10_i2c_data *data = dev->data;
+
+	/* Notify backend */
+	modem_backend_ublox_i2c_mon_rxr(&data->i2c_backend, awake,
+					pm_device_runtime_usage(dev) > 0);
+}
+
 static int ubx_m10_i2c_init(const struct device *dev)
 {
 	const struct ubx_m10_i2c_config *cfg = dev->config;
@@ -525,9 +534,9 @@ static DEVICE_API(gnss, gnss_api) = {
 
 #define UBX_M10_I2C(inst)                                                                          \
 	static const struct ubx_m10_i2c_config ubx_m10_cfg_##inst = {                              \
-		.common = UBX_COMMON_CONFIG_INST(inst, ubx_m10_i2c_software_standby,               \
-						 ubx_m10_i2c_software_resume,                      \
-						 ubx_m10_i2c_port_setup, ubx_m10_fifo_poll),       \
+		.common = UBX_COMMON_CONFIG_INST(                                                  \
+			inst, ubx_m10_i2c_software_standby, ubx_m10_i2c_software_resume,           \
+			ubx_m10_i2c_port_setup, ubx_m10_fifo_poll, ubx_m10_mon_rxr),               \
 		.i2c = I2C_DT_SPEC_INST_GET(inst),                                                 \
 		.rf_lna_mode = DT_INST_ENUM_IDX(inst, rf_lna_mode),                                \
 	};                                                                                         \

--- a/drivers/gnss/gnss_u_blox_m10_i2c.c
+++ b/drivers/gnss/gnss_u_blox_m10_i2c.c
@@ -532,11 +532,17 @@ static DEVICE_API(gnss, gnss_api) = {
 	.get_latest_timepulse = ubx_common_get_latest_timepulse,
 };
 
+static const struct ubx_common_pm_fn ubx_m10_i2c_pm_fn = {
+	.software_standby = ubx_m10_i2c_software_standby,
+	.software_resume = ubx_m10_i2c_software_resume,
+	.port_setup = ubx_m10_i2c_port_setup,
+	.fifo_poll = ubx_m10_fifo_poll,
+	.mon_rxr = ubx_m10_mon_rxr,
+};
+
 #define UBX_M10_I2C(inst)                                                                          \
 	static const struct ubx_m10_i2c_config ubx_m10_cfg_##inst = {                              \
-		.common = UBX_COMMON_CONFIG_INST(                                                  \
-			inst, ubx_m10_i2c_software_standby, ubx_m10_i2c_software_resume,           \
-			ubx_m10_i2c_port_setup, ubx_m10_fifo_poll, ubx_m10_mon_rxr),               \
+		.common = UBX_COMMON_CONFIG_INST(inst, &ubx_m10_i2c_pm_fn),                        \
 		.i2c = I2C_DT_SPEC_INST_GET(inst),                                                 \
 		.rf_lna_mode = DT_INST_ENUM_IDX(inst, rf_lna_mode),                                \
 	};                                                                                         \

--- a/drivers/gnss/gnss_u_blox_m8_emul.c
+++ b/drivers/gnss/gnss_u_blox_m8_emul.c
@@ -137,6 +137,11 @@ void ubx_modem_extint_control(const struct device *dev, bool high)
 	ARG_UNUSED(high);
 }
 
+void ubx_modem_extint_wake(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+}
+
 void emul_gnss_pvt_configure(const struct device *dev, struct gnss_pvt_emul_location *emul_location)
 {
 	struct emul_data *data = dev->data;

--- a/drivers/gnss/gnss_u_blox_m8_spi.c
+++ b/drivers/gnss/gnss_u_blox_m8_spi.c
@@ -474,6 +474,14 @@ static void ubx_m8_fifo_poll(const struct device *dev)
 	k_work_reschedule(&data->spi_backend.common.fifo_read, K_NO_WAIT);
 }
 
+static void ubx_m8_mon_rxr(const struct device *dev, bool awake)
+{
+	struct ubx_m8_spi_data *data = dev->data;
+
+	/* Notify backend */
+	modem_backend_ublox_spi_mon_rxr(&data->spi_backend, awake);
+}
+
 static int ubx_m8_spi_init(const struct device *dev)
 {
 	const struct ubx_m8_spi_config *cfg = dev->config;
@@ -508,9 +516,9 @@ static DEVICE_API(gnss, gnss_api) = {
 
 #define UBX_M8_SPI(inst)                                                                           \
 	static const struct ubx_m8_spi_config ubx_m8_cfg_##inst = {                                \
-		.common = UBX_COMMON_CONFIG_INST(inst, ubx_m8_spi_software_standby,                \
-						 ubx_m8_spi_software_resume,                       \
-						 ubx_m8_spi_port_setup, ubx_m8_fifo_poll),         \
+		.common = UBX_COMMON_CONFIG_INST(                                                  \
+			inst, ubx_m8_spi_software_standby, ubx_m8_spi_software_resume,             \
+			ubx_m8_spi_port_setup, ubx_m8_fifo_poll, ubx_m8_mon_rxr),                  \
 		.spi = SPI_DT_SPEC_INST_GET(inst, SPI_WORD_SET(8) | SPI_TRANSFER_MSB),             \
 	};                                                                                         \
 	static struct ubx_m8_spi_data ubx_m8_data_##inst;                                          \

--- a/drivers/gnss/gnss_u_blox_m8_spi.c
+++ b/drivers/gnss/gnss_u_blox_m8_spi.c
@@ -514,11 +514,17 @@ static DEVICE_API(gnss, gnss_api) = {
 	.get_latest_timepulse = ubx_common_get_latest_timepulse,
 };
 
+static const struct ubx_common_pm_fn ubx_m8_spi_pm_fn = {
+	.software_standby = ubx_m8_spi_software_standby,
+	.software_resume = ubx_m8_spi_software_resume,
+	.port_setup = ubx_m8_spi_port_setup,
+	.fifo_poll = ubx_m8_fifo_poll,
+	.mon_rxr = ubx_m8_mon_rxr,
+};
+
 #define UBX_M8_SPI(inst)                                                                           \
 	static const struct ubx_m8_spi_config ubx_m8_cfg_##inst = {                                \
-		.common = UBX_COMMON_CONFIG_INST(                                                  \
-			inst, ubx_m8_spi_software_standby, ubx_m8_spi_software_resume,             \
-			ubx_m8_spi_port_setup, ubx_m8_fifo_poll, ubx_m8_mon_rxr),                  \
+		.common = UBX_COMMON_CONFIG_INST(inst, &ubx_m8_spi_pm_fn),                         \
 		.spi = SPI_DT_SPEC_INST_GET(inst, SPI_WORD_SET(8) | SPI_TRANSFER_MSB),             \
 	};                                                                                         \
 	static struct ubx_m8_spi_data ubx_m8_data_##inst;                                          \

--- a/drivers/gnss/gnss_ubx_common.c
+++ b/drivers/gnss/gnss_ubx_common.c
@@ -176,6 +176,11 @@ void ubx_modem_extint_control(const struct device *dev, bool high)
 	gpio_pin_set_raw(cfg->extint_gpio.port, cfg->extint_gpio.pin, high ? 1 : 0);
 }
 
+void ubx_modem_extint_wake(const struct device *dev)
+{
+	return ubx_common_extint_wake(dev);
+}
+
 void ubx_common_extint_wake(const struct device *dev)
 {
 	const struct ubx_common_config *cfg = dev->config;

--- a/drivers/gnss/gnss_ubx_common.c
+++ b/drivers/gnss/gnss_ubx_common.c
@@ -166,7 +166,7 @@ void ubx_modem_fifo_poll(const struct device *dev)
 {
 	const struct ubx_common_config *cfg = dev->config;
 
-	cfg->pm_funcs.fifo_poll(dev);
+	cfg->pm_funcs->fifo_poll(dev);
 }
 
 void ubx_modem_extint_control(const struct device *dev, bool high)
@@ -235,7 +235,7 @@ static int mon_rxr_handler(uint8_t message_class, uint8_t message_id, const void
 	struct ubx_common_data *data = dev->data;
 
 	/* Notify backend on MON-RXR */
-	cfg->pm_funcs.mon_rxr(dev, mon_rxr->flags & UBX_MSG_MON_RXR_AWAKE);
+	cfg->pm_funcs->mon_rxr(dev, mon_rxr->flags & UBX_MSG_MON_RXR_AWAKE);
 
 	LOG_DBG("MON-RXR: %02X", mon_rxr->flags);
 	return k_poll_signal_raise(&data->mon_rxr_signal, mon_rxr->flags);
@@ -258,7 +258,7 @@ int ubx_common_pm_control(const struct device *dev, enum pm_device_action action
 							      GPIO_INT_DISABLE);
 		}
 		/* Put into low power mode */
-		rc = cfg->pm_funcs.software_standby(dev);
+		rc = cfg->pm_funcs->software_standby(dev);
 		if (rc < 0) {
 			LOG_WRN("Failed to go to standby mode");
 			/* It is important here that even if the modem backend reports a failure,
@@ -277,7 +277,7 @@ int ubx_common_pm_control(const struct device *dev, enum pm_device_action action
 		ubx_modem_software_standby(&data->modem);
 		break;
 	case PM_DEVICE_ACTION_RESUME:
-		rc = cfg->pm_funcs.software_resume(dev);
+		rc = cfg->pm_funcs->software_resume(dev);
 		if (rc < 0) {
 			LOG_WRN("Failed to resume");
 			return rc;
@@ -321,14 +321,14 @@ int ubx_common_pm_control(const struct device *dev, enum pm_device_action action
 			return rc;
 		}
 		/* Configure modem for comms */
-		rc = cfg->pm_funcs.port_setup(dev, hardware_reset);
+		rc = cfg->pm_funcs->port_setup(dev, hardware_reset);
 		if (rc < 0) {
 			LOG_INF("Failed to setup comms port");
 			modem_pipe_close(data->modem.pipe, K_SECONDS(2));
 			return rc;
 		}
 		/* Put into low power mode */
-		rc = cfg->pm_funcs.software_standby(dev);
+		rc = cfg->pm_funcs->software_standby(dev);
 		if (rc < 0) {
 			LOG_INF("Failed to go to standby mode");
 			modem_pipe_close(data->modem.pipe, K_SECONDS(2));

--- a/drivers/gnss/gnss_ubx_common.c
+++ b/drivers/gnss/gnss_ubx_common.c
@@ -230,10 +230,15 @@ static int mon_rxr_handler(uint8_t message_class, uint8_t message_id, const void
 			   size_t payload_len, void *user_data)
 {
 	const struct ubx_msg_mon_rxr *mon_rxr = payload;
-	struct k_poll_signal *sig = user_data;
+	const struct device *dev = user_data;
+	const struct ubx_common_config *cfg = dev->config;
+	struct ubx_common_data *data = dev->data;
+
+	/* Notify backend on MON-RXR */
+	cfg->pm_funcs.mon_rxr(dev, mon_rxr->flags & UBX_MSG_MON_RXR_AWAKE);
 
 	LOG_DBG("MON-RXR: %02X", mon_rxr->flags);
-	return k_poll_signal_raise(sig, mon_rxr->flags);
+	return k_poll_signal_raise(&data->mon_rxr_signal, mon_rxr->flags);
 }
 
 int ubx_common_pm_control(const struct device *dev, enum pm_device_action action)
@@ -349,7 +354,7 @@ int ubx_common_init(const struct device *dev, struct modem_pipe *pipe)
 		.message_class = UBX_MSG_CLASS_MON,
 		.message_id = UBX_MSG_ID_MON_RXR,
 		.message_cb = mon_rxr_handler,
-		.user_data = &data->mon_rxr_signal,
+		.user_data = (void *)dev,
 	};
 	k_poll_signal_init(&data->mon_rxr_signal);
 	ubx_modem_msg_subscribe(&data->modem, &data->mon_rxr_handler);

--- a/drivers/gnss/u_blox_common.h
+++ b/drivers/gnss/u_blox_common.h
@@ -34,7 +34,7 @@ struct ubx_common_pm_fn {
 };
 
 struct ubx_common_config {
-	struct ubx_common_pm_fn pm_funcs;
+	const struct ubx_common_pm_fn *pm_funcs;
 	struct shared_device_dt_spec ant_switch;
 	struct gpio_dt_spec reset_gpio;
 	struct gpio_dt_spec extint_gpio;
@@ -66,16 +66,9 @@ struct ubx_common_data {
 #endif /* CONFIG_GNSS_U_BLOX_NO_API_COMPAT */
 };
 
-#define UBX_COMMON_CONFIG_INST(inst, standby_fn, resume_fn, setup_fn, fifo_poll_fn, mon_rxr_fn)    \
+#define UBX_COMMON_CONFIG_INST(inst, _pm_funcs)                                                    \
 	{                                                                                          \
-		.pm_funcs =                                                                        \
-			{                                                                          \
-				.software_standby = standby_fn,                                    \
-				.software_resume = resume_fn,                                      \
-				.port_setup = setup_fn,                                            \
-				.fifo_poll = fifo_poll_fn,                                         \
-				.mon_rxr = mon_rxr_fn,                                             \
-			},                                                                         \
+		.pm_funcs = _pm_funcs,                                                             \
 		.ant_switch = SHARED_DEVICE_DT_SPEC_INST_GET_OR(inst, antenna_switch, {0}),        \
 		.reset_gpio = GPIO_DT_SPEC_INST_GET(inst, reset_gpios),                            \
 		.extint_gpio = GPIO_DT_SPEC_INST_GET(inst, extint_gpios),                          \

--- a/drivers/gnss/u_blox_common.h
+++ b/drivers/gnss/u_blox_common.h
@@ -30,6 +30,7 @@ struct ubx_common_pm_fn {
 	int (*software_resume)(const struct device *dev);
 	int (*port_setup)(const struct device *dev, bool hardware_reset);
 	void (*fifo_poll)(const struct device *dev);
+	void (*mon_rxr)(const struct device *dev, bool awake);
 };
 
 struct ubx_common_config {
@@ -65,7 +66,7 @@ struct ubx_common_data {
 #endif /* CONFIG_GNSS_U_BLOX_NO_API_COMPAT */
 };
 
-#define UBX_COMMON_CONFIG_INST(inst, standby_fn, resume_fn, setup_fn, fifo_poll_fn)                \
+#define UBX_COMMON_CONFIG_INST(inst, standby_fn, resume_fn, setup_fn, fifo_poll_fn, mon_rxr_fn)    \
 	{                                                                                          \
 		.pm_funcs =                                                                        \
 			{                                                                          \
@@ -73,6 +74,7 @@ struct ubx_common_data {
 				.software_resume = resume_fn,                                      \
 				.port_setup = setup_fn,                                            \
 				.fifo_poll = fifo_poll_fn,                                         \
+				.mon_rxr = mon_rxr_fn,                                             \
 			},                                                                         \
 		.ant_switch = SHARED_DEVICE_DT_SPEC_INST_GET_OR(inst, antenna_switch, {0}),        \
 		.reset_gpio = GPIO_DT_SPEC_INST_GET(inst, reset_gpios),                            \

--- a/generated/include_always/infuse/task_runner/tasks/gnss_args.h
+++ b/generated/include_always/infuse/task_runner/tasks/gnss_args.h
@@ -114,6 +114,8 @@ struct task_gnss_args {
 	union schedule_union_task_gnss_mode_args mode;
 	/** Dynamic model from ubx_cfg_key_navspg_dynmodel */
 	uint8_t dynamic_model;
+	/** Number of seconds between GNSS measurements (0 == 1 second) */
+	uint8_t measurement_period_s;
 } __packed;
 
 #ifdef __cplusplus

--- a/include/infuse/gnss/ubx/cfg.h
+++ b/include/infuse/gnss/ubx/cfg.h
@@ -11,6 +11,8 @@
 #ifndef INFUSE_GNSS_UBX_CFG_H_
 #define INFUSE_GNSS_UBX_CFG_H_
 
+#include <stdbool.h>
+
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/byteorder.h>
 
@@ -1036,6 +1038,31 @@ static inline void ubx_msg_prepare_valget(struct net_buf_simple *buf, uint8_t la
 	valget->position = offset;
 }
 
+/** @cond INTERNAL_HIDDEN */
+
+static inline void _ubx_cfg_value_append_1bit(struct net_buf_simple *buf, bool value)
+{
+	net_buf_simple_add_u8(buf, value ? 0x01 : 0x00);
+}
+
+/**
+ * @brief Select value append function based on key size
+ *
+ * @param key_size Key size to select function for
+ */
+#define _UBX_CFG_VALUE_APPEND_FN(key_size)                                                         \
+	__builtin_choose_expr(                                                                     \
+		key_size == _UBX_CFG_KEY_SIZE_1BIT_, _ubx_cfg_value_append_1bit,                   \
+		__builtin_choose_expr(                                                             \
+			key_size == _UBX_CFG_KEY_SIZE_1BYTE, net_buf_simple_add_u8,                \
+			__builtin_choose_expr(                                                     \
+				key_size == _UBX_CFG_KEY_SIZE_2BYTE, net_buf_simple_add_le16,      \
+				__builtin_choose_expr(key_size == _UBX_CFG_KEY_SIZE_4BYTE,         \
+						      net_buf_simple_add_le32,                     \
+						      net_buf_simple_add_le64))))
+
+/** @endcond */
+
 /**
  * @brief Macro to append a configuration value to a buffer
  *
@@ -1048,24 +1075,10 @@ static inline void ubx_msg_prepare_valget(struct net_buf_simple *buf, uint8_t la
  * @param value Value
  */
 #define UBX_CFG_VALUE_APPEND(buf, key, value)                                                      \
-	net_buf_simple_add_le32(buf, key);                                                         \
-	switch (key & _UBX_CFG_KEY_SIZE_MASK) {                                                    \
-	case _UBX_CFG_KEY_SIZE_1BIT_:                                                              \
-		net_buf_simple_add_u8(buf, value ? 0x01 : 0x00);                                   \
-		break;                                                                             \
-	case _UBX_CFG_KEY_SIZE_1BYTE:                                                              \
-		net_buf_simple_add_u8(buf, value);                                                 \
-		break;                                                                             \
-	case _UBX_CFG_KEY_SIZE_2BYTE:                                                              \
-		net_buf_simple_add_le16(buf, value);                                               \
-		break;                                                                             \
-	case _UBX_CFG_KEY_SIZE_4BYTE:                                                              \
-		net_buf_simple_add_le32(buf, value);                                               \
-		break;                                                                             \
-	default:                                                                                   \
-		net_buf_simple_add_le64(buf, value);                                               \
-		break;                                                                             \
-	}
+	do {                                                                                       \
+		net_buf_simple_add_le32(buf, key);                                                 \
+		_UBX_CFG_VALUE_APPEND_FN(((key) & _UBX_CFG_KEY_SIZE_MASK))(buf, value);            \
+	} while (0)
 
 /** Configuration value structure as returned by parser */
 struct ubx_cfg_val {

--- a/include/infuse/gnss/ubx/modem.h
+++ b/include/infuse/gnss/ubx/modem.h
@@ -120,6 +120,13 @@ void ubx_modem_fifo_poll(const struct device *dev);
 void ubx_modem_extint_control(const struct device *dev, bool high);
 
 /**
+ * @brief Trigger a wakeup of the UBX modem via EXTINT pin
+ *
+ * @param dev Modem device
+ */
+void ubx_modem_extint_wake(const struct device *dev);
+
+/**
  * @brief Initialise UBX modem handler
  *
  * @param modem Modem data structure

--- a/include/infuse/modem/backend/u_blox_i2c.h
+++ b/include/infuse/modem/backend/u_blox_i2c.h
@@ -58,6 +58,16 @@ modem_backend_ublox_i2c_init(struct modem_backend_ublox_i2c *backend,
  */
 void modem_backend_ublox_i2c_use_data_ready_gpio(struct modem_backend_ublox_i2c *backend);
 
+/**
+ * @brief MON-RXR message handler to track modem state
+ *
+ * @param backend Modem backend data structure
+ * @param awake True if modem is awake, false if asleep
+ * @param pm_active True if device is requested to be PM_ACTIVE, false otherwise
+ */
+void modem_backend_ublox_i2c_mon_rxr(struct modem_backend_ublox_i2c *backend, bool awake,
+				     bool pm_active);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/infuse/modem/backend/u_blox_spi.h
+++ b/include/infuse/modem/backend/u_blox_spi.h
@@ -60,6 +60,14 @@ modem_backend_ublox_spi_init(struct modem_backend_ublox_spi *backend,
  */
 void modem_backend_ublox_spi_use_data_ready_gpio(struct modem_backend_ublox_spi *backend);
 
+/**
+ * @brief MON-RXR message handler to track modem state
+ *
+ * @param backend Modem backend data structure
+ * @param awake True if modem is awake, false if asleep
+ */
+void modem_backend_ublox_spi_mon_rxr(struct modem_backend_ublox_spi *backend, bool awake);
+
 #ifdef __cplusplus
 }
 #endif

--- a/scripts/west_commands/cloud_definitions/tasks.json
+++ b/scripts/west_commands/cloud_definitions/tasks.json
@@ -278,7 +278,8 @@
                 {"name": "accuracy_m", "type": "uint16_t", "description": "Accuracy in meters"},
                 {"name": "position_dop", "type": "uint16_t", "description": "Dilution of precision, scaled by 0.1"},
                 {"name": "mode", "type": "union schedule_union_task_gnss_mode_args", "description": "Mode-specific arguments selected by flags"},
-                {"name": "dynamic_model", "type": "uint8_t", "description": "Dynamic model from ubx_cfg_key_navspg_dynmodel"}
+                {"name": "dynamic_model", "type": "uint8_t", "description": "Dynamic model from ubx_cfg_key_navspg_dynmodel"},
+                {"name": "measurement_period_s", "type": "uint8_t", "description": "Number of seconds between GNSS measurements (0 == 1 second)"}
             ]
         },
         "5": {

--- a/subsys/modem/backends/modem_backend_u_blox_i2c.c
+++ b/subsys/modem/backends/modem_backend_u_blox_i2c.c
@@ -21,6 +21,7 @@ enum {
 	MODE_BOOTING = BIT(0),
 	MODE_POLLING = BIT(1),
 	MODE_CLOSED = BIT(2),
+	MODE_INACTIVE = BIT(3),
 };
 
 static void write_cb(struct rtio *r, const struct rtio_sqe *sqe, int res, void *arg)
@@ -120,9 +121,23 @@ static void fifo_bytes_pending_cb(struct rtio *r, const struct rtio_sqe *sqe, in
 
 	/* If in polling mode, or query failed */
 	if ((backend->common.flags & MODE_POLLING) || failed) {
-		/* Reschedule another data poll */
-		k_work_reschedule(&backend->common.fifo_read, backend->common.poll_period);
+		/* Reschedule another data poll, even if modem is asleep.
+		 * M10 I2C has a known bug where TX-READY will not assert after a sleep cycle, so we
+		 * need to poll in order to learn when the module is awake.
+		 */
+		k_timeout_t poll_period = (backend->common.flags & MODE_INACTIVE)
+						  ? K_MSEC(1000)
+						  : backend->common.poll_period;
+
+		k_work_reschedule(&backend->common.fifo_read, poll_period);
 	}
+
+	/* If the poll succeeded, the modem is no longer inactive */
+	if (!failed && (backend->common.flags & MODE_INACTIVE)) {
+		LOG_DBG("Modem ACTIVE");
+		backend->common.flags &= ~MODE_INACTIVE;
+	}
+
 	/* If we aren't running the FIFO read */
 	if (failed || (backend->common.bytes_pending == 0)) {
 		/* Release bus */
@@ -358,4 +373,24 @@ void modem_backend_ublox_i2c_use_data_ready_gpio(struct modem_backend_ublox_i2c 
 	(void)gpio_pin_interrupt_configure_dt(backend->common.data_ready, GPIO_INT_EDGE_TO_ACTIVE);
 	/* Trigger a query immediately in case line already high */
 	k_work_reschedule(&backend->common.fifo_read, K_NO_WAIT);
+}
+
+void modem_backend_ublox_i2c_mon_rxr(struct modem_backend_ublox_i2c *backend, bool awake,
+				     bool pm_active)
+{
+	LOG_DBG("MON-RXR: %s", awake ? "ACTIVE" : "INACTIVE");
+	if (awake) {
+		backend->common.flags &= ~MODE_INACTIVE;
+	} else {
+		backend->common.flags |= MODE_INACTIVE;
+		if (pm_active) {
+			/* Device is still in use by application but in the inactive state (PSMCT or
+			 * PSMOO).
+			 * Unfortunately the TX-READY pin never asserts until we initiate an I2C
+			 * transaction due to modem firmware bug, schedule a periodic poll so that
+			 * we are notified within 1 second of the modem waking up.
+			 */
+			k_work_reschedule(&backend->common.fifo_read, K_MSEC(1000));
+		}
+	}
 }

--- a/subsys/modem/backends/modem_backend_u_blox_spi.c
+++ b/subsys/modem/backends/modem_backend_u_blox_spi.c
@@ -269,3 +269,10 @@ void modem_backend_ublox_spi_use_data_ready_gpio(struct modem_backend_ublox_spi 
 	/* Trigger a query immediately in case line already high */
 	k_work_reschedule(&backend->common.fifo_read, K_NO_WAIT);
 }
+
+void modem_backend_ublox_spi_mon_rxr(struct modem_backend_ublox_spi *backend, bool awake)
+{
+	/* Not currently supported */
+	ARG_UNUSED(backend);
+	ARG_UNUSED(awake);
+}

--- a/subsys/task_runner/tasks/task_gnss_nrf9x.c
+++ b/subsys/task_runner/tasks/task_gnss_nrf9x.c
@@ -39,6 +39,7 @@ static struct gnss_run_state {
 	uint64_t next_time_sync;
 	uint32_t time_acquired;
 	uint32_t task_start;
+	uint16_t fix_interval;
 	atomic_t events;
 	uint8_t flags;
 } state;
@@ -64,6 +65,14 @@ static int nrf9x_gnss_boot(const struct task_gnss_args *args)
 	uint32_t dynamics;
 	int rc;
 
+	state.fix_interval = args->measurement_period_s;
+	if (state.fix_interval == 0) {
+		state.fix_interval = 1;
+	} else if ((state.fix_interval > 1) && (state.fix_interval < 10)) {
+		LOG_WRN("nRF9x GNSS does not support rates between 2 and 9 seconds");
+		state.fix_interval = 1;
+	}
+
 	rc = lte_lc_func_mode_set(LTE_LC_FUNC_MODE_ACTIVATE_GNSS);
 	if (rc != 0) {
 		LOG_ERR("Failed to %s (%d)", "activate GNSS", rc);
@@ -79,7 +88,7 @@ static int nrf9x_gnss_boot(const struct task_gnss_args *args)
 		LOG_ERR("Failed to %s (%d)", "set use case", rc);
 		return rc;
 	}
-	rc = nrf_modem_gnss_fix_interval_set(1);
+	rc = nrf_modem_gnss_fix_interval_set(state.fix_interval);
 	if (rc != 0) {
 		LOG_ERR("Failed to %s (%d)", "set fix interval", rc);
 		return rc;
@@ -425,6 +434,6 @@ termination:
 		return;
 	}
 
-	/* Expect another callback within 2 seconds */
-	task_workqueue_reschedule(task, K_SECONDS(2));
+	/* Expect another callback according to the fix interval */
+	task_workqueue_reschedule(task, K_SECONDS(state.fix_interval + 1));
 }

--- a/subsys/task_runner/tasks/task_gnss_ubx.c
+++ b/subsys/task_runner/tasks/task_gnss_ubx.c
@@ -317,12 +317,15 @@ static int nav_sat_cb(uint8_t message_class, uint8_t message_id, const void *pay
 }
 #endif /* CONFIG_TASK_RUNNER_GNSS_SATELLITE_INFO */
 
-/* extint_force_active:
- *    true: Modem is forced into ACTIVE mode while EXTINT is high
- *   false: Modem is not forced into any mode
+/* low_power_possible:
+ *    true: Modem can transition to a low power state (PSMCT or PSMOO)
+ *   false: Modem stays in full power state (PSMFF)
+ *  max_sleep_s:
+ *    If configured for low power operation, the maximum expectde duration between
+ *    modem wakeups in seconds.
  */
 static int gnss_configure(const struct device *gnss, const struct task_gnss_args *args,
-			  uint32_t *max_sleep_s, bool *extint_force_active)
+			  bool *low_power_possible, uint32_t *max_sleep_s)
 {
 	struct ubx_modem_data *modem = ubx_modem_data_get(gnss);
 	uint8_t run_target = (args->flags & TASK_GNSS_FLAGS_RUN_MASK);
@@ -332,7 +335,7 @@ static int gnss_configure(const struct device *gnss, const struct task_gnss_args
 	int rc;
 
 	/* Default modes, modem never sleeps */
-	*extint_force_active = false;
+	*low_power_possible = false;
 	*max_sleep_s = 0;
 
 	/* Constellation configuration if requested */
@@ -404,15 +407,11 @@ static int gnss_configure(const struct device *gnss, const struct task_gnss_args
 			UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_PM_ACQPERIOD,
 					     args->mode.low_power.search_period);
 			UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_PM_DONOTENTEROFF, false);
-
-			/* Force the modem out of backup mode when EXTINT is "high" so we can
-			 * talk to the modem when desired.
-			 */
-			UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_PM_EXTINTWAKE, true);
-			*extint_force_active = true;
+			UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_PM_EXTINTWAKE, false);
 
 			/* Modem can sleep for up to `search_period` seconds */
-			*max_sleep_s = args->mode.low_power.search_period + 2;
+			*low_power_possible = true;
+			*max_sleep_s = args->mode.low_power.search_period;
 		}
 
 		UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_PM_OPERATEMODE,
@@ -473,25 +472,6 @@ static int gnss_configure(const struct device *gnss, const struct task_gnss_args
 	return rc;
 }
 
-static void extint_ctrl_reset(const struct device *gnss)
-{
-#ifdef CONFIG_GNSS_UBX_M10
-	struct ubx_modem_data *modem = ubx_modem_data_get(gnss);
-	int rc;
-
-	NET_BUF_SIMPLE_DEFINE(cfg_buf, 32);
-	ubx_msg_prepare_valset(&cfg_buf,
-			       UBX_MSG_CFG_VALSET_LAYERS_RAM | UBX_MSG_CFG_VALSET_LAYERS_BBR);
-	UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_PM_EXTINTWAKE, false);
-
-	ubx_msg_finalise(&cfg_buf);
-	rc = ubx_modem_send_sync_acked(modem, &cfg_buf, K_MSEC(250));
-	if (rc < 0) {
-		LOG_WRN("Failed to reset EXTINT control");
-	}
-#endif /* CONFIG_GNSS_UBX_M10 */
-}
-
 static int retry_power_up(const struct device *gnss)
 {
 	int rc;
@@ -534,7 +514,7 @@ void gnss_task_fn(const struct task_schedule *schedule, struct k_poll_signal *te
 		.message_cb = mon_rxr_cb,
 		.user_data = &run_state,
 	};
-	bool extint_force_active;
+	bool low_power_possible;
 	uint32_t data_timeout;
 	uint32_t max_sleep_s;
 	int rc;
@@ -570,12 +550,12 @@ void gnss_task_fn(const struct task_schedule *schedule, struct k_poll_signal *te
 	}
 
 	/* Configure the modem according to the arguments */
-	rc = gnss_configure(gnss, args, &max_sleep_s, &extint_force_active);
+	rc = gnss_configure(gnss, args, &low_power_possible, &max_sleep_s);
 	if (rc < 0) {
 		rc = retry_power_up(gnss);
 		if (rc == 0) {
 			/* Try again */
-			(void)gnss_configure(gnss, args, &max_sleep_s, &extint_force_active);
+			(void)gnss_configure(gnss, args, &low_power_possible, &max_sleep_s);
 		} else {
 			/* Cycling the modem failed */
 			k_sleep(K_SECONDS(1));
@@ -612,28 +592,21 @@ void gnss_task_fn(const struct task_schedule *schedule, struct k_poll_signal *te
 		K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY,
 					 &run_state.receiver_idle),
 	};
+	bool receiver_idle = false;
 	int signaled, result;
 
-	if (extint_force_active) {
-		/* Don't want to force modem active while running */
-		ubx_modem_extint_control(gnss, false);
-	}
 	data_timeout = k_uptime_seconds();
-
 	while (1) {
 		/* Block on the NAV-PVT callback and Task Runner requests */
 		if (k_poll(events, ARRAY_SIZE(events), K_SECONDS(2)) == -EAGAIN) {
-			if (k_uptime_seconds() >= data_timeout) {
+			if (!receiver_idle) {
+				/* Modem is expected to be awake, but no data has arrived */
+				LOG_WRN("Terminating due to %s", "no data");
+				break;
+			} else if (k_uptime_seconds() >= data_timeout) {
 				/* Data has not arrived within the expected time */
 				LOG_WRN("Terminating due to %s", "data timeout");
 				break;
-			}
-			if (max_sleep_s > 0) {
-				/* Modem is expected to sleep, poll to see if it is back awake.
-				 * Required since the comms interfaces also go to sleep (despite
-				 * the EXTENDEDTIMEOUT setting...)
-				 */
-				ubx_modem_fifo_poll(gnss);
 			}
 		}
 		k_poll_signal_check(terminate, &signaled, &result);
@@ -644,20 +617,29 @@ void gnss_task_fn(const struct task_schedule *schedule, struct k_poll_signal *te
 		k_poll_signal_check(&run_state.nav_pvt_rx, &signaled, &result);
 		if (signaled) {
 			k_poll_signal_reset(&run_state.nav_pvt_rx);
+			if (receiver_idle) {
+				LOG_INF("Receiver active");
+				receiver_idle = false;
+			}
 			if (nav_pvt_handle(&run_state, args)) {
 				break;
 			}
-			data_timeout = k_uptime_seconds() + max_sleep_s;
 		}
 		k_poll_signal_check(&run_state.nav_timegps_rx, &signaled, &result);
 		if (signaled) {
 			k_poll_signal_reset(&run_state.nav_timegps_rx);
+			if (receiver_idle) {
+				LOG_INF("Receiver active");
+				receiver_idle = false;
+			}
 			nav_timegps_handle(&run_state, args);
-			data_timeout = k_uptime_seconds() + max_sleep_s;
 		}
 		k_poll_signal_check(&run_state.receiver_idle, &signaled, &result);
 		if (signaled) {
 			k_poll_signal_reset(&run_state.receiver_idle);
+			receiver_idle = true;
+			data_timeout = k_uptime_seconds() + max_sleep_s + 2;
+			LOG_INF("Receiver idle");
 		}
 	}
 
@@ -692,12 +674,9 @@ void gnss_task_fn(const struct task_schedule *schedule, struct k_poll_signal *te
 	ubx_modem_msg_unsubscribe(run_state.modem, &sat_handler_ctx);
 #endif /* CONFIG_TASK_RUNNER_GNSS_SATELLITE_INFO */
 
-	if (extint_force_active) {
-		/* Modem could be in sleep mode, need to force active */
-		ubx_modem_extint_control(gnss, 1);
-		k_sleep(K_MSEC(250));
-		/* Stop EXTINT forcing the power state */
-		extint_ctrl_reset(gnss);
+	if (low_power_possible) {
+		/* Modem could be in sleep mode, wake via EXTINT pin */
+		ubx_modem_extint_wake(gnss);
 	}
 
 	/* Release power requirement */

--- a/subsys/task_runner/tasks/task_gnss_ubx.c
+++ b/subsys/task_runner/tasks/task_gnss_ubx.c
@@ -329,7 +329,7 @@ static int nav_sat_cb(uint8_t message_class, uint8_t message_id, const void *pay
  *    modem wakeups in seconds.
  */
 static int gnss_configure(const struct device *gnss, const struct task_gnss_args *args,
-			  bool *low_power_possible, uint32_t *max_sleep_s)
+			  uint16_t meas_rate, bool *low_power_possible, uint32_t *max_sleep_s)
 {
 	struct ubx_modem_data *modem = ubx_modem_data_get(gnss);
 	uint8_t run_target = (args->flags & TASK_GNSS_FLAGS_RUN_MASK);
@@ -391,6 +391,8 @@ static int gnss_configure(const struct device *gnss, const struct task_gnss_args
 	UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_TP_TIMEGRID_TP1, UBX_CFG_TP_TIMEGRID_TP1_GPS);
 	/* Platform dynamics */
 	UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_NAVSPG_DYNMODEL, dynamics);
+	/* Measurement rate */
+	UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_RATE_MEAS, meas_rate);
 	ubx_msg_finalise(&cfg_buf);
 	rc = ubx_modem_send_sync_acked(modem, &cfg_buf, K_MSEC(250));
 	if (rc < 0) {
@@ -445,7 +447,7 @@ static int gnss_configure(const struct device *gnss, const struct task_gnss_args
 #ifdef CONFIG_GNSS_UBX_M8
 	NET_BUF_SIMPLE_DEFINE(msg_buf, 48);
 	const struct ubx_msg_cfg_rate cfg_rate = {
-		.meas_rate = 1000,
+		.meas_rate = meas_rate,
 		.nav_rate = 1,
 		.time_ref = UBX_MSG_CFG_RATE_TIME_REF_GPS,
 	};
@@ -530,6 +532,7 @@ void gnss_task_fn(const struct task_schedule *schedule, struct k_poll_signal *te
 	bool low_power_possible;
 	uint32_t data_timeout;
 	uint32_t max_sleep_s;
+	uint16_t meas_rate;
 	int rc;
 
 	run_state.dev = gnss;
@@ -562,13 +565,18 @@ void gnss_task_fn(const struct task_schedule *schedule, struct k_poll_signal *te
 		return;
 	}
 
+	/* Milliseconds between measurments according to args */
+	meas_rate = args->measurement_period_s == 0 ? 1 : MIN(args->measurement_period_s, 60);
+	meas_rate *= MSEC_PER_SEC;
+
 	/* Configure the modem according to the arguments */
-	rc = gnss_configure(gnss, args, &low_power_possible, &max_sleep_s);
+	rc = gnss_configure(gnss, args, meas_rate, &low_power_possible, &max_sleep_s);
 	if (rc < 0) {
 		rc = retry_power_up(gnss);
 		if (rc == 0) {
 			/* Try again */
-			(void)gnss_configure(gnss, args, &low_power_possible, &max_sleep_s);
+			(void)gnss_configure(gnss, args, meas_rate, &low_power_possible,
+					     &max_sleep_s);
 		} else {
 			/* Cycling the modem failed */
 			k_sleep(K_SECONDS(1));
@@ -611,7 +619,7 @@ void gnss_task_fn(const struct task_schedule *schedule, struct k_poll_signal *te
 	data_timeout = k_uptime_seconds();
 	while (1) {
 		/* Block on the NAV-PVT callback and Task Runner requests */
-		if (k_poll(events, ARRAY_SIZE(events), K_SECONDS(2)) == -EAGAIN) {
+		if (k_poll(events, ARRAY_SIZE(events), K_MSEC(meas_rate + 1000)) == -EAGAIN) {
 			if (!receiver_idle) {
 				/* Modem is expected to be awake, but no data has arrived */
 				LOG_WRN("Terminating due to %s", "no data");

--- a/subsys/task_runner/tasks/task_gnss_ubx.c
+++ b/subsys/task_runner/tasks/task_gnss_ubx.c
@@ -383,7 +383,19 @@ static int gnss_configure(const struct device *gnss, const struct task_gnss_args
 	/* Satellite information message */
 	UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_MSGOUT_UBX_NAV_SAT_I2C, 1);
 #endif /* CONFIG_TASK_RUNNER_GNSS_SATELLITE_INFO */
+	/* Align timepulse to GPS time */
+	UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_TP_TIMEGRID_TP1, UBX_CFG_TP_TIMEGRID_TP1_GPS);
+	/* Platform dynamics */
+	UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_NAVSPG_DYNMODEL, dynamics);
+	ubx_msg_finalise(&cfg_buf);
+	rc = ubx_modem_send_sync_acked(modem, &cfg_buf, K_MSEC(250));
+	if (rc < 0) {
+		LOG_WRN("Failed to configure modem");
+	}
+
 	/* Power mode configuration */
+	ubx_msg_prepare_valset(&cfg_buf,
+			       UBX_MSG_CFG_VALSET_LAYERS_RAM | UBX_MSG_CFG_VALSET_LAYERS_BBR);
 	if (performance_mode) {
 		/* Normal mode tracking (default values) */
 		UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_NAVSPG_OUTFIL_PACC, 100);
@@ -417,10 +429,6 @@ static int gnss_configure(const struct device *gnss, const struct task_gnss_args
 		UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_PM_OPERATEMODE,
 				     UBX_CFG_PM_OPERATEMODE_PSMCT);
 	}
-	/* Align timepulse to GPS time */
-	UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_TP_TIMEGRID_TP1, UBX_CFG_TP_TIMEGRID_TP1_GPS);
-	/* Platform dynamics */
-	UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_NAVSPG_DYNMODEL, dynamics);
 
 	ubx_msg_finalise(&cfg_buf);
 	rc = ubx_modem_send_sync_acked(modem, &cfg_buf, K_MSEC(250));

--- a/subsys/task_runner/tasks/task_gnss_ubx.c
+++ b/subsys/task_runner/tasks/task_gnss_ubx.c
@@ -408,8 +408,9 @@ static int gnss_configure(const struct device *gnss, const struct task_gnss_args
 		UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_NAVSPG_OUTFIL_PDOP, args->position_dop);
 		UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_PM_ONTIME, 0);
 		UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_PM_UPDATEEPH, true);
-		if (args->mode.low_power.acquisition_timeout == 0) {
-			/* No acquisition timeout */
+		if ((args->mode.low_power.acquisition_timeout == 0) &&
+		    (args->mode.low_power.search_period == 0)) {
+			/* No acquisition or search timeout */
 			UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_PM_MAXACQTIME, 0);
 			UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_PM_DONOTENTEROFF, true);
 		} else {

--- a/subsys/task_runner/tasks/task_gnss_ubx.c
+++ b/subsys/task_runner/tasks/task_gnss_ubx.c
@@ -52,6 +52,7 @@ struct gnss_run_state {
 	struct ubx_msg_nav_timegps latest_timegps;
 	struct k_poll_signal nav_pvt_rx;
 	struct k_poll_signal nav_timegps_rx;
+	struct k_poll_signal receiver_idle;
 	struct gnss_fix_timeout_state timeout_state;
 	uint64_t next_time_sync;
 	uint32_t task_start;
@@ -276,6 +277,19 @@ static bool nav_pvt_handle(struct gnss_run_state *state, const struct task_gnss_
 
 	/* Continue fix */
 	return false;
+}
+
+static int mon_rxr_cb(uint8_t message_class, uint8_t message_id, const void *payload,
+		      size_t payload_len, void *user_data)
+{
+	const struct ubx_msg_mon_rxr *rxr = payload;
+	struct gnss_run_state *state = user_data;
+
+	if (!(rxr->flags & UBX_MSG_MON_RXR_AWAKE)) {
+		/* Notify task thread receiver is going to sleep */
+		k_poll_signal_raise(&state->receiver_idle, 0);
+	}
+	return 0;
 }
 
 #ifdef CONFIG_TASK_RUNNER_GNSS_SATELLITE_INFO
@@ -514,6 +528,12 @@ void gnss_task_fn(const struct task_schedule *schedule, struct k_poll_signal *te
 		.message_cb = nav_pvt_cb,
 		.user_data = &run_state,
 	};
+	struct ubx_message_handler_ctx mon_rxr_handler_ctx = {
+		.message_class = UBX_MSG_CLASS_MON,
+		.message_id = UBX_MSG_ID_MON_RXR,
+		.message_cb = mon_rxr_cb,
+		.user_data = &run_state,
+	};
 	bool extint_force_active;
 	uint32_t data_timeout;
 	uint32_t max_sleep_s;
@@ -528,6 +548,7 @@ void gnss_task_fn(const struct task_schedule *schedule, struct k_poll_signal *te
 	gnss_timeout_reset(&run_state.timeout_state);
 	k_poll_signal_init(&run_state.nav_pvt_rx);
 	k_poll_signal_init(&run_state.nav_timegps_rx);
+	k_poll_signal_init(&run_state.receiver_idle);
 
 	LOG_DBG("Starting");
 
@@ -566,6 +587,9 @@ void gnss_task_fn(const struct task_schedule *schedule, struct k_poll_signal *te
 	/* Subscribe to NAV-PVT message */
 	ubx_modem_msg_subscribe(run_state.modem, &pvt_handler_ctx);
 
+	/* Subscribe to MON-RXR to be notified when modem goes idle */
+	ubx_modem_msg_subscribe(run_state.modem, &mon_rxr_handler_ctx);
+
 #ifdef CONFIG_TASK_RUNNER_GNSS_SATELLITE_INFO
 	struct ubx_message_handler_ctx sat_handler_ctx = {
 		.message_class = UBX_MSG_CLASS_NAV,
@@ -585,6 +609,8 @@ void gnss_task_fn(const struct task_schedule *schedule, struct k_poll_signal *te
 					 &run_state.nav_pvt_rx),
 		K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY,
 					 &run_state.nav_timegps_rx),
+		K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY,
+					 &run_state.receiver_idle),
 	};
 	int signaled, result;
 
@@ -629,6 +655,10 @@ void gnss_task_fn(const struct task_schedule *schedule, struct k_poll_signal *te
 			nav_timegps_handle(&run_state, args);
 			data_timeout = k_uptime_seconds() + max_sleep_s;
 		}
+		k_poll_signal_check(&run_state.receiver_idle, &signaled, &result);
+		if (signaled) {
+			k_poll_signal_reset(&run_state.receiver_idle);
+		}
 	}
 
 	/* Log at end of run for a location fix */
@@ -657,6 +687,7 @@ void gnss_task_fn(const struct task_schedule *schedule, struct k_poll_signal *te
 
 	/* Cleanup message subscription */
 	ubx_modem_msg_unsubscribe(run_state.modem, &pvt_handler_ctx);
+	ubx_modem_msg_unsubscribe(run_state.modem, &mon_rxr_handler_ctx);
 #ifdef CONFIG_TASK_RUNNER_GNSS_SATELLITE_INFO
 	ubx_modem_msg_unsubscribe(run_state.modem, &sat_handler_ctx);
 #endif /* CONFIG_TASK_RUNNER_GNSS_SATELLITE_INFO */

--- a/subsys/task_runner/tasks/task_gnss_ubx.c
+++ b/subsys/task_runner/tasks/task_gnss_ubx.c
@@ -218,18 +218,22 @@ static bool nav_pvt_handle(struct gnss_run_state *state, const struct task_gnss_
 	bool valid_time = (pvt->valid & time_validity) == time_validity;
 	bool valid_hacc = (pvt->h_acc <= (1000 * (uint32_t)args->accuracy_m));
 	bool valid_pdop = (pvt->p_dop <= (10 * (uint32_t)args->position_dop));
+	bool fix_ok = (pvt->flags & UBX_MSG_NAV_PVT_FLAGS_GNSS_FIX_OK) != 0;
+	uint8_t psm_state = (pvt->flags & UBX_MSG_NAV_PVT_FLAGS_PSM_MASK) >> 2;
 	bool not_running = !(state->flags & TIME_SYNC_RUNNING);
 	uint32_t runtime = k_uptime_seconds() - state->task_start;
 
 	/* Periodically print fix state */
 	if (k_uptime_seconds() % 30 == 0) {
-		LOG_INF("NAV-PVT: Lat: %9d Lon: %9d Height: %6d", pvt->lat, pvt->lon, pvt->height);
-		LOG_INF("         HAcc: %umm VAcc: %umm pDOP: %d NumSV: %d", pvt->h_acc, pvt->v_acc,
-			pvt->p_dop / 100, pvt->num_sv);
+		LOG_INF("NAV-PVT: Lat: %9d Lon: %9d Height: %6d Ok: %d", pvt->lat, pvt->lon,
+			pvt->height, fix_ok);
+		LOG_INF("         HAcc: %umm VAcc: %umm pDOP: %d NumSV: %d PSM: %d", pvt->h_acc,
+			pvt->v_acc, pvt->p_dop / 100, pvt->num_sv, psm_state);
 	} else {
-		LOG_DBG("NAV-PVT: Lat: %9d Lon: %9d Height: %6d", pvt->lat, pvt->lon, pvt->height);
-		LOG_DBG("         HAcc: %umm VAcc: %umm pDOP: %d NumSV: %d", pvt->h_acc, pvt->v_acc,
-			pvt->p_dop / 100, pvt->num_sv);
+		LOG_DBG("NAV-PVT: Lat: %9d Lon: %9d Height: %6d Ok: %d", pvt->lat, pvt->lon,
+			pvt->height, fix_ok);
+		LOG_DBG("         HAcc: %umm VAcc: %umm pDOP: %d NumSV: %d PSM: %d", pvt->h_acc,
+			pvt->v_acc, pvt->p_dop / 100, pvt->num_sv, psm_state);
 	}
 
 	if (run_target == TASK_GNSS_FLAGS_RUN_FOREVER) {

--- a/subsys/task_runner/tasks/task_gnss_ubx.c
+++ b/subsys/task_runner/tasks/task_gnss_ubx.c
@@ -357,7 +357,7 @@ static int gnss_configure(const struct device *gnss, const struct task_gnss_args
 	}
 
 #ifdef CONFIG_GNSS_UBX_M10
-	NET_BUF_SIMPLE_DEFINE(cfg_buf, 80);
+	NET_BUF_SIMPLE_DEFINE(cfg_buf, 100);
 	ubx_msg_prepare_valset(&cfg_buf,
 			       UBX_MSG_CFG_VALSET_LAYERS_RAM | UBX_MSG_CFG_VALSET_LAYERS_BBR);
 	/* Core location message */
@@ -374,15 +374,17 @@ static int gnss_configure(const struct device *gnss, const struct task_gnss_args
 		UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_PM_OPERATEMODE,
 				     UBX_CFG_PM_OPERATEMODE_FULL);
 	} else {
-		/* Cyclic Tracking, entering POT ASAP, no acquisition timeout */
+		/* Cyclic Tracking, entering POT ASAP */
 		UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_NAVSPG_OUTFIL_PACC, args->accuracy_m);
 		UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_NAVSPG_OUTFIL_PDOP, args->position_dop);
 		UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_PM_ONTIME, 0);
 		UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_PM_UPDATEEPH, true);
 		if (args->mode.low_power.acquisition_timeout == 0) {
+			/* No acquisition timeout */
 			UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_PM_MAXACQTIME, 0);
 			UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_PM_DONOTENTEROFF, true);
 		} else {
+			/* Timeouts according to schedule */
 			UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_PM_MAXACQTIME,
 					     args->mode.low_power.acquisition_timeout);
 			UBX_CFG_VALUE_APPEND(&cfg_buf, UBX_CFG_KEY_PM_ACQPERIOD,

--- a/subsys/task_runner/tasks/task_gnss_zephyr.c
+++ b/subsys/task_runner/tasks/task_gnss_zephyr.c
@@ -226,6 +226,7 @@ void gnss_task_fn(const struct task_schedule *schedule, struct k_poll_signal *te
 	uint8_t run_target = (args->flags & TASK_GNSS_FLAGS_RUN_MASK);
 	struct gnss_run_state run_state = {0};
 	gnss_systems_t constellations;
+	uint16_t meas_rate;
 	uint8_t dynamics;
 	int rc;
 
@@ -243,6 +244,8 @@ void gnss_task_fn(const struct task_schedule *schedule, struct k_poll_signal *te
 	run_state.task_start = k_uptime_seconds();
 	cb_state = &run_state;
 	gnss_timeout_reset(&run_state.timeout_state);
+	meas_rate = args->measurement_period_s == 0 ? 1 : MIN(args->measurement_period_s, 60);
+	meas_rate *= MSEC_PER_SEC;
 
 	LOG_DBG("Starting");
 
@@ -307,7 +310,7 @@ void gnss_task_fn(const struct task_schedule *schedule, struct k_poll_signal *te
 	}
 
 	/* Configure output fix rate */
-	rc = gnss_set_fix_rate(gnss, 1000);
+	rc = gnss_set_fix_rate(gnss, meas_rate);
 	if (rc != 0) {
 		LOG_WRN("Failed to configure fix rate (%d)", rc);
 	}
@@ -322,7 +325,7 @@ void gnss_task_fn(const struct task_schedule *schedule, struct k_poll_signal *te
 
 	while (1) {
 		/* Block on the NAV-PVT callback and Task Runner requests */
-		if (k_poll(events, ARRAY_SIZE(events), K_SECONDS(2)) == -EAGAIN) {
+		if (k_poll(events, ARRAY_SIZE(events), K_MSEC(meas_rate + 1000)) == -EAGAIN) {
 			LOG_WRN("Terminating due to %s", "callback timeout");
 			break;
 		}

--- a/tests/subsys/task_runner/tasks/gnss/src/main.c
+++ b/tests/subsys/task_runner/tasks/gnss/src/main.c
@@ -12,6 +12,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gnss.h>
 #include <zephyr/drivers/gnss/gnss_emul.h>
+#include <zephyr/pm/device_runtime.h>
 
 #include <infuse/time/epoch.h>
 #include <infuse/epacket/packet.h>
@@ -400,6 +401,62 @@ ZTEST(task_gnss, test_run_forever)
 	zassert_true(task_wait(thread, K_SECONDS(2)));
 }
 
+ZTEST(task_gnss, test_measurement_period_3_seconds)
+{
+#ifdef CONFIG_TASK_RUNNER_TASK_GNSS_NRF9X
+	ztest_test_skip();
+#else
+	struct gnss_pvt_emul_location emul_loc = {
+		.latitude = -270000100,
+		.longitude = 1530009000,
+		.height = 56412,
+		.h_acc = 500,
+		.v_acc = 500,
+		.t_acc = 5,
+		.p_dop = 10,
+		.num_sv = 8,
+	};
+	k_tid_t thread;
+
+	schedule.timeout_s = 0;
+	schedule.task_logging[0].loggers = TDF_DATA_LOGGER_SERIAL;
+	schedule.task_logging[0].tdf_mask = TASK_GNSS_LOG_LLHA;
+	schedule.task_args.gnss = (struct task_gnss_args){
+		.flags = TASK_GNSS_FLAGS_RUN_FOREVER,
+		.measurement_period_s = 3,
+	};
+
+	/* Start the thread */
+	thread = task_schedule(&data);
+
+	/* First location should be published promptly after startup. */
+	zassert_equal(0, k_sem_take(&location_published, K_MSEC(3500)));
+	k_sleep(K_TICKS(1));
+	expected_logging(-910000000, -1810000000, 0, INT32_MAX, INT32_MAX, 1);
+
+	/* Second location might come in early as well (emulators) */
+	zassert_equal(0, k_sem_take(&location_published, K_MSEC(3500)));
+	k_sleep(K_TICKS(1));
+	expected_logging(-910000000, -1810000000, 0, INT32_MAX, INT32_MAX, 1);
+
+	/* Set location for next report */
+	emul_gnss_pvt_configure(DEV, &emul_loc);
+
+	/* Measurement period is configured to 3 seconds. */
+	zassert_equal(-EAGAIN, k_sem_take(&location_published, K_MSEC(2500)));
+	zassert_equal(0, k_sem_take(&location_published, K_MSEC(1100)));
+	k_sleep(K_TICKS(1));
+	expected_logging(emul_loc.latitude, emul_loc.longitude, emul_loc.height, emul_loc.h_acc,
+			 emul_loc.v_acc, 1);
+
+	/* Until requested to stop */
+	k_poll_signal_raise(&data.terminate_signal, 0);
+
+	/* Thread should terminated */
+	zassert_true(task_wait(thread, K_SECONDS(2)));
+#endif /* CONFIG_TASK_RUNNER_TASK_GNSS_NRF9X */
+}
+
 ZTEST(task_gnss, test_location_fix)
 {
 	gnss_systems_t sys_default, sys_enabled;
@@ -734,4 +791,14 @@ static void logger_before(void *fixture)
 #endif /* CONFIG_GNSS_UBX_MODEM_EMUL */
 }
 
-ZTEST_SUITE(task_gnss, NULL, NULL, logger_before, NULL, NULL);
+static void run_after(void *fixture)
+{
+#ifdef CONFIG_GNSS_EMUL
+	/* Reset the fix rate between runs due to emulator quirks */
+	pm_device_runtime_get(DEV);
+	gnss_set_fix_rate(DEV, 1000);
+	pm_device_runtime_put(DEV);
+#endif /* CONFIG_GNSS_EMUL */
+}
+
+ZTEST_SUITE(task_gnss, NULL, NULL, logger_before, run_after, NULL);


### PR DESCRIPTION
Improve the low power behaviour of PSMCT by waking the modem through a
EXTINT edge when terminating, instead of requiring `EXTINTWAKE` to be
set. This prevents ~300 uA of current draw due to a pull-up resistor
on the EXTINT pin and the necessity of `EXTINTWAKE` to drive the pin
low.

Also improves data timeout detection by only accepting long periods of
inactivity when the receiver is idle.