### PR TITLE
rpc: commands: bt_file_copy_basic: extend timeout

### DIFF
--- a/subsys/rpc/commands/bt_file_copy_basic.c
+++ b/subsys/rpc/commands/bt_file_copy_basic.c
@@ -158,6 +158,7 @@ int rpc_command_bt_file_copy_basic_run(struct rpc_bt_file_copy_basic_request *re
 	rpc_server_watchdog_feed();
 
 	/* Wait for initial ACK */
+	LOG_INF("Waiting ACK");
 	rc = rpc_client_ack_wait(&client_ctx, request_id, K_SECONDS(15));
 	if (rc < 0) {
 		LOG_WRN("Initial ACK not received");
@@ -168,6 +169,7 @@ int rpc_command_bt_file_copy_basic_run(struct rpc_bt_file_copy_basic_request *re
 	if (k_sem_take(&completion_ctx.done, K_NO_WAIT) == 0) {
 		/* Command terminated before first ACK */
 		rc = completion_ctx.rc;
+		LOG_INF("Early termination: %d", rc);
 		goto cleanup;
 	}
 
@@ -178,6 +180,8 @@ int rpc_command_bt_file_copy_basic_run(struct rpc_bt_file_copy_basic_request *re
 	}
 
 	work_mem = rpc_server_command_working_mem(&work_mem_size);
+
+	LOG_INF("Starting copy of %d bytes", load_params.total_len);
 
 	/* Push the data through the client, loaded from the flash area */
 	rc = rpc_client_data_queue_auto_load(&client_ctx, request_id, 0, work_mem, work_mem_size,

--- a/subsys/rpc/commands/bt_file_copy_basic.c
+++ b/subsys/rpc/commands/bt_file_copy_basic.c
@@ -134,7 +134,7 @@ int rpc_command_bt_file_copy_basic_run(struct rpc_bt_file_copy_basic_request *re
 	/* Queue the initiating command */
 	rc = rpc_client_command_queue(&client_ctx, RPC_ID_FILE_WRITE_BASIC, &write_req,
 				      sizeof(write_req), command_data_done, &completion_ctx,
-				      K_NO_WAIT, K_SECONDS(10));
+				      K_NO_WAIT, K_SECONDS(15));
 	if (rc < 0) {
 		LOG_WRN("Failed to queue initial command");
 		goto cleanup;


### PR DESCRIPTION
Extend the RPC client timeout to the same duration that `rpc_client_ack_wait` waits for. This allows the server to take up to the full 15 seconds to provide the first response, needed for larger files on storage that is slow to erase.