### PR TITLE
rpc: commands: common_file_action: fix `SWAP_USING_OFFSET` handling

### DIFF
--- a/subsys/rpc/commands/common_file_actions.c
+++ b/subsys/rpc/commands/common_file_actions.c
@@ -108,6 +108,9 @@ static int flash_area_check_and_erase(struct rpc_common_file_actions_ctx *ctx, u
 	}
 	if ((crc != UINT32_MAX) && (len != UINT32_MAX)) {
 		rc = flash_area_crc32(ctx->fa, partition_offset, len, &current_crc, mem, mem_size);
+		if (rc < 0) {
+			goto close_area;
+		}
 		if (current_crc == crc) {
 			ctx->crc = crc;
 			return FILE_ALREADY_PRESENT;

--- a/subsys/rpc/commands/common_file_actions.c
+++ b/subsys/rpc/commands/common_file_actions.c
@@ -82,7 +82,8 @@ static void cpatch_watchdog(uint32_t progress, uint32_t total)
 }
 
 static int flash_area_check_and_erase(struct rpc_common_file_actions_ctx *ctx, uint8_t partition_id,
-				      uint32_t *length, uint32_t crc, bool mcuboot_trailer)
+				      off_t partition_offset, uint32_t *length, uint32_t crc,
+				      bool mcuboot_trailer)
 {
 	uint32_t len = *length;
 	uint32_t current_crc;
@@ -97,26 +98,38 @@ static int flash_area_check_and_erase(struct rpc_common_file_actions_ctx *ctx, u
 
 	/* Check if file contents already match */
 	rc = pm_flash_area_open(partition_id, &ctx->fa);
-	if (rc == 0) {
-		if ((crc != UINT32_MAX) && (len != UINT32_MAX)) {
-			rc = flash_area_crc32(ctx->fa, 0, len, &current_crc, mem, mem_size);
-			if (current_crc == crc) {
-				ctx->crc = crc;
-				return FILE_ALREADY_PRESENT;
-			}
+	if (rc != 0) {
+		return rc;
+	}
+	if ((partition_offset < 0) || (partition_offset >= ctx->fa->fa_size)) {
+		/* Invalid offset */
+		rc = -EINVAL;
+		goto close_area;
+	}
+	if ((crc != UINT32_MAX) && (len != UINT32_MAX)) {
+		rc = flash_area_crc32(ctx->fa, partition_offset, len, &current_crc, mem, mem_size);
+		if (current_crc == crc) {
+			ctx->crc = crc;
+			return FILE_ALREADY_PRESENT;
 		}
-		/* Limit erase size to flash area size */
-		if (len == UINT32_MAX) {
-			len = ctx->fa->fa_size;
-			*length = len;
-		}
-		/* Erase space for image */
-		rc = infuse_dfu_image_erase(ctx->fa, len, cpatch_watchdog, mcuboot_trailer);
-		if (rc != 0) {
-			/* Close flash area */
-			(void)pm_flash_area_close(ctx->fa);
-			ctx->fa = NULL;
-		}
+	}
+	if (len == UINT32_MAX) {
+		len = ctx->fa->fa_size - partition_offset;
+		*length = len;
+	} else {
+	}
+	if (len > (ctx->fa->fa_size - partition_offset)) {
+		rc = -EINVAL;
+		goto close_area;
+	}
+	/* Erase space for image */
+	rc = infuse_dfu_image_erase(ctx->fa, partition_offset + len, cpatch_watchdog,
+				    mcuboot_trailer);
+close_area:
+	if (rc != 0) {
+		/* Close flash area */
+		(void)pm_flash_area_close(ctx->fa);
+		ctx->fa = NULL;
 	}
 	return rc;
 }
@@ -124,14 +137,14 @@ static int flash_area_check_and_erase(struct rpc_common_file_actions_ctx *ctx, u
 static int common_file_actions_stream_writer_init(struct rpc_common_file_actions_ctx *ctx,
 						  uint8_t partition_id,
 						  const struct device *partition_dev,
-						  off_t partition_offset, size_t file_len,
-						  uint32_t crc, bool trailer)
+						  off_t write_offset, off_t partition_offset,
+						  size_t file_len, uint32_t crc, bool trailer)
 {
 	const struct flash_parameters *params = flash_get_parameters(partition_dev);
 	int rc;
 
 	/* Setup flash for file to write */
-	rc = flash_area_check_and_erase(ctx, partition_id, &file_len, crc, trailer);
+	rc = flash_area_check_and_erase(ctx, partition_id, write_offset, &file_len, crc, trailer);
 	if (rc == FILE_ALREADY_PRESENT) {
 		return rc;
 	} else if (rc < 0) {
@@ -141,14 +154,14 @@ static int common_file_actions_stream_writer_init(struct rpc_common_file_actions
 	/* Round up write size to write alignment */
 	file_len = ROUND_UP(file_len, params->write_block_size);
 	return stream_flash_init(&ctx->stream_ctx, partition_dev, common_file_actions_write_buffer,
-				 sizeof(common_file_actions_write_buffer), partition_offset,
-				 file_len, NULL);
+				 sizeof(common_file_actions_write_buffer),
+				 partition_offset + write_offset, file_len, NULL);
 }
 
-#define STREAM_WRITER_INIT(ctx, partition, offset, length, crc, trailer)                           \
-	common_file_actions_stream_writer_init(                                                    \
-		ctx, PARTITION_ID(partition), PARTITION_DEVICE(partition),                         \
-		PARTITION_OFFSET(partition) + offset, length, crc, trailer)
+#define STREAM_WRITER_INIT(ctx, partition, write_offset, length, crc, trailer)                     \
+	common_file_actions_stream_writer_init(ctx, PARTITION_ID(partition),                       \
+					       PARTITION_DEVICE(partition), write_offset,          \
+					       PARTITION_OFFSET(partition), length, crc, trailer)
 
 #endif /* APP_IMG || APP_CPATCH || FILE_COPY_RAW */
 
@@ -203,7 +216,7 @@ int rpc_common_file_actions_start(struct rpc_common_file_actions_ctx *ctx,
 				  enum infuse_littlefs_folder fs_folder, uint32_t fs_file,
 				  uint32_t fs_identifier)
 {
-	__maybe_unused off_t offset;
+	__maybe_unused off_t write_offset;
 	int rc = 0;
 
 	ctx->fa = NULL;
@@ -222,8 +235,8 @@ int rpc_common_file_actions_start(struct rpc_common_file_actions_ctx *ctx,
 		break;
 #ifdef SUPPORT_APP_IMG
 	case RPC_ENUM_FILE_ACTION_APP_IMG:
-		offset = boot_get_image_start_offset(PARTITION_ID(slot1_partition));
-		rc = STREAM_WRITER_INIT(ctx, slot1_partition, offset, length, crc, true);
+		write_offset = boot_get_image_start_offset(PARTITION_ID(slot1_partition));
+		rc = STREAM_WRITER_INIT(ctx, slot1_partition, write_offset, length, crc, true);
 		break;
 #endif /* SUPPORT_APP_IMG */
 #ifdef SUPPORT_APP_CPATCH

--- a/subsys/rpc/commands/common_file_actions.c
+++ b/subsys/rpc/commands/common_file_actions.c
@@ -373,6 +373,7 @@ static int finish_cpatch(struct rpc_common_file_actions_ctx *ctx)
 	struct cpatch_header header;
 	size_t mem_size, out_len;
 	uint32_t flash_offset;
+	uint32_t image_offset;
 	uint8_t *mem;
 	int rc;
 
@@ -394,12 +395,15 @@ static int finish_cpatch(struct rpc_common_file_actions_ctx *ctx)
 	if (rc < 0) {
 		goto cleanup;
 	}
+	image_offset = boot_get_image_start_offset(PARTITION_ID(slot1_partition));
 
 #if !defined(CONFIG_STREAM_FLASH_ERASE)
 
-	LOG_INF("Erasing %d bytes of secondary partition", header.output_file.length);
+	LOG_INF("Erasing %d bytes of secondary partition",
+		image_offset + header.output_file.length);
 	/* Erase space for image */
-	rc = infuse_dfu_image_erase(fa_output, header.output_file.length, cpatch_watchdog, true);
+	rc = infuse_dfu_image_erase(fa_output, image_offset + header.output_file.length,
+				    cpatch_watchdog, true);
 	if (rc < 0) {
 		goto cleanup;
 	}
@@ -421,8 +425,7 @@ static int finish_cpatch(struct rpc_common_file_actions_ctx *ctx)
 	/* Limit buffer size to common flash erase size */
 	mem_size = MIN(mem_size, 4096);
 	/* Required offset of the image in the flash area */
-	flash_offset = PARTITION_OFFSET(slot1_partition) +
-		       boot_get_image_start_offset(PARTITION_ID(slot1_partition));
+	flash_offset = PARTITION_OFFSET(slot1_partition) + image_offset;
 	rc = stream_flash_init(&stream_ctx, PARTITION_DEVICE(slot1_partition), mem, mem_size,
 			       flash_offset, out_len, NULL);
 	__ASSERT_NO_MSG(rc == 0);

--- a/subsys/rpc/commands/common_file_actions.c
+++ b/subsys/rpc/commands/common_file_actions.c
@@ -115,6 +115,7 @@ static int flash_area_check_and_erase(struct rpc_common_file_actions_ctx *ctx, u
 		if (rc != 0) {
 			/* Close flash area */
 			(void)pm_flash_area_close(ctx->fa);
+			ctx->fa = NULL;
 		}
 	}
 	return rc;
@@ -613,13 +614,19 @@ int rpc_common_file_actions_error_cleanup(struct rpc_common_file_actions_ctx *ct
 #endif /* SUPPORT_APP_CPATCH */
 	case RPC_ENUM_FILE_ACTION_APP_IMG:
 		/* Close the flash area */
-		pm_flash_area_close(ctx->fa);
+		if (ctx->fa != NULL) {
+			pm_flash_area_close(ctx->fa);
+			ctx->fa = NULL;
+		}
 		break;
 #endif /* SUPPORT_APP_IMG */
 #ifdef SUPPORT_FILE_COPY_RAW
 	case RPC_ENUM_FILE_ACTION_FILE_FOR_COPY:
 		/* Close the flash area */
-		pm_flash_area_close(ctx->fa);
+		if (ctx->fa != NULL) {
+			pm_flash_area_close(ctx->fa);
+			ctx->fa = NULL;
+		}
 		break;
 #endif /* SUPPORT_FILE_COPY_RAW */
 #ifdef SUPPORT_FILE_COPY_FS

--- a/tests/subsys/rpc/commands/file_write_basic/mcuboot_offset.overlay
+++ b/tests/subsys/rpc/commands/file_write_basic/mcuboot_offset.overlay
@@ -1,0 +1,13 @@
+/ {
+	chosen {
+		zephyr,code-partition = &slot0_partition;
+	};
+};
+
+&slot0_partition {
+	compatible = "zephyr,mapped-partition";
+};
+
+&slot1_partition {
+	compatible = "zephyr,mapped-partition";
+};

--- a/tests/subsys/rpc/commands/file_write_basic/src/main.c
+++ b/tests/subsys/rpc/commands/file_write_basic/src/main.c
@@ -12,6 +12,7 @@
 #include <zephyr/sys/crc.h>
 #include <zephyr/storage/flash_map.h>
 #include <zephyr/pm/device_runtime.h>
+#include <zephyr/dfu/mcuboot.h>
 
 #include <infuse/bluetooth/controller_manager.h>
 #include <infuse/dfu/helpers.h>
@@ -28,6 +29,7 @@
 
 static uint8_t fixed_payload[8192];
 static uint32_t fixed_payload_crc;
+static uint8_t cpatch_payload[8192];
 
 struct test_out {
 	int16_t cmd_rc;
@@ -92,11 +94,11 @@ __maybe_unused static void zassert_device_released(const struct device *dev)
 	zassert_equal(0, usage);
 }
 
-static struct test_out test_file_write_basic(uint8_t action, uint32_t total_send,
-					     uint8_t skip_after, uint8_t stop_after,
-					     uint8_t bad_id_after, uint8_t ack_period,
-					     bool too_much_data, bool expect_skip,
-					     const void *fixed_source)
+static struct test_out test_file_write_basic_declared(uint8_t action, uint32_t total_send,
+						      uint32_t declared_size, uint8_t skip_after,
+						      uint8_t stop_after, uint8_t bad_id_after,
+						      uint8_t ack_period, bool too_much_data,
+						      bool expect_skip, const void *fixed_source)
 {
 	const struct device *epacket_dummy = DEVICE_DT_GET(DT_NODELABEL(epacket_dummy));
 	struct k_fifo *tx_fifo = epacket_dummmy_transmit_fifo_get();
@@ -132,7 +134,7 @@ static struct test_out test_file_write_basic(uint8_t action, uint32_t total_send
 	header.type = INFUSE_RPC_CMD;
 	header.auth = EPACKET_AUTH_NETWORK;
 	req->header.request_id = request_id;
-	req->data_header.size = send_remaining;
+	req->data_header.size = declared_size;
 	req->data_header.rx_ack_period = ack_period;
 	req->action = action;
 	req->file_crc = crc;
@@ -261,6 +263,17 @@ early_rsp:
 	return ret;
 }
 
+static struct test_out test_file_write_basic(uint8_t action, uint32_t total_send,
+					     uint8_t skip_after, uint8_t stop_after,
+					     uint8_t bad_id_after, uint8_t ack_period,
+					     bool too_much_data, bool expect_skip,
+					     const void *fixed_source)
+{
+	return test_file_write_basic_declared(action, total_send, total_send, skip_after,
+					      stop_after, bad_id_after, ack_period, too_much_data,
+					      expect_skip, fixed_source);
+}
+
 void validate_flash_area(struct test_out *ret, uint8_t partition_id)
 {
 #if PARTITION_EXISTS(slot1_partition)
@@ -270,8 +283,44 @@ void validate_flash_area(struct test_out *ret, uint8_t partition_id)
 	uint32_t fa_crc;
 
 	zassert_equal(0, flash_area_open(partition_id, &fa));
-	zassert_equal(0, flash_area_crc32(fa, 0, ret->cmd_len, &fa_crc, buffer, sizeof(buffer)));
+	zassert_equal(0, flash_area_crc32(fa, boot_get_image_start_offset(partition_id),
+					  ret->cmd_len, &fa_crc, buffer, sizeof(buffer)));
 	zassert_equal(ret->cmd_crc, fa_crc, "CRC sent does not equal CRC written");
+	flash_area_close(fa);
+#endif /* PARTITION_EXISTS(slot1_partition) */
+}
+
+__maybe_unused static void validate_flash_area_offset(struct test_out *ret, uint8_t partition_id,
+						      off_t offset)
+{
+#if PARTITION_EXISTS(slot1_partition)
+	uint8_t buffer[128];
+	const struct flash_area *fa;
+	uint32_t fa_crc;
+
+	zassert_equal(0, flash_area_open(partition_id, &fa));
+	zassert_equal(0,
+		      flash_area_crc32(fa, offset, ret->cmd_len, &fa_crc, buffer, sizeof(buffer)));
+	zassert_equal(ret->cmd_crc, fa_crc, "CRC sent does not equal CRC written");
+	flash_area_close(fa);
+#endif /* PARTITION_EXISTS(slot1_partition) */
+}
+
+__maybe_unused static void fill_flash_area(uint8_t partition_id, uint8_t value)
+{
+#if PARTITION_EXISTS(slot1_partition)
+	uint8_t buffer[128];
+	const struct flash_area *fa;
+
+	memset(buffer, value, sizeof(buffer));
+
+	zassert_equal(0, flash_area_open(partition_id, &fa));
+	zassert_equal(0, flash_area_erase(fa, 0, fa->fa_size));
+	for (size_t offset = 0; offset < fa->fa_size; offset += sizeof(buffer)) {
+		size_t len = MIN(sizeof(buffer), fa->fa_size - offset);
+
+		zassert_equal(0, flash_area_write(fa, offset, buffer, len));
+	}
 	flash_area_close(fa);
 #endif /* PARTITION_EXISTS(slot1_partition) */
 }
@@ -403,8 +452,62 @@ ZTEST(rpc_command_file_write_basic, test_file_write_dfu)
 
 	zassert_device_released(slot1_dev);
 }
+
+ZTEST(rpc_command_file_write_basic, test_file_write_dfu_unknown_len_offset)
+{
+	size_t image_offset = boot_get_image_start_offset(PARTITION_ID(slot1_partition));
+	const struct device *slot1_dev = PARTITION_DEVICE(slot1_partition);
+	const struct flash_area *fa;
+	struct test_out ret;
+	uint32_t payload_len = 16000;
+
+	if (image_offset == 0) {
+		ztest_test_skip();
+	}
+
+	zassert_device_released(slot1_dev);
+	zassert_equal(0, flash_area_open(PARTITION_ID(slot1_partition), &fa));
+	zassert_true(payload_len <= fa->fa_size - image_offset);
+	flash_area_close(fa);
+
+	fill_flash_area(PARTITION_ID(slot1_partition), 0x00);
+
+	ret = test_file_write_basic_declared(RPC_ENUM_FILE_ACTION_APP_IMG, payload_len, UINT32_MAX,
+					     0, 0, 0, 0, false, false, NULL);
+	zassert_equal(-ETIMEDOUT, ret.cmd_rc);
+	zassert_equal(payload_len, ret.cmd_len);
+	zassert_equal(ret.written_crc, ret.cmd_crc);
+
+	zassert_equal(0, infuse_dfu_write_erase_call_count());
+	zassert_device_released(slot1_dev);
+}
+
+ZTEST(rpc_command_file_write_basic, test_file_write_dfu_too_large_releases_device)
+{
+	const struct device *slot1_dev = PARTITION_DEVICE(slot1_partition);
+	struct test_out ret;
+
+	zassert_device_released(slot1_dev);
+
+	ret = test_file_write_basic_declared(RPC_ENUM_FILE_ACTION_APP_IMG, 0, UINT32_MAX / 2, 0, 0,
+					     0, 0, false, false, NULL);
+	zassert_equal(-EINVAL, ret.cmd_rc);
+	zassert_equal(0, ret.cmd_len);
+	zassert_equal(0, infuse_dfu_write_erase_call_count());
+	zassert_device_released(slot1_dev);
+}
 #else
 ZTEST(rpc_command_file_write_basic, test_file_write_dfu)
+{
+	ztest_test_skip();
+}
+
+ZTEST(rpc_command_file_write_basic, test_file_write_dfu_unknown_len_offset)
+{
+	ztest_test_skip();
+}
+
+ZTEST(rpc_command_file_write_basic, test_file_write_dfu_too_large_releases_device)
 {
 	ztest_test_skip();
 }
@@ -412,17 +515,20 @@ ZTEST(rpc_command_file_write_basic, test_file_write_dfu)
 
 static uint8_t flash_copy_buffer[CONFIG_INFUSE_RPC_COMMON_FILE_ACTIONS_WRITE_BUFFER];
 
-static void flash_area_copy_wrapped(uint8_t partition_dst, uint8_t partition_src, uint32_t len,
-				    bool source_erase)
+static void flash_area_copy_wrapped(uint8_t partition_dst, off_t dst_offset, uint8_t partition_src,
+				    off_t src_offset, uint32_t len, bool source_erase)
 {
 	const struct flash_area *fa_dst, *fa_src;
+	size_t copy_len;
 
 	zassert_equal(0, flash_area_open(partition_dst, &fa_dst));
 	zassert_equal(0, flash_area_open(partition_src, &fa_src));
 
 	zassert_equal(0, flash_area_erase(fa_dst, 0, fa_dst->fa_size));
-	zassert_equal(0, flash_area_copy(fa_src, 0, fa_dst, 0, fa_dst->fa_size, flash_copy_buffer,
-					 sizeof(flash_copy_buffer)));
+	copy_len = MIN(fa_dst->fa_size - dst_offset, fa_src->fa_size - src_offset);
+	zassert_true(len <= copy_len);
+	zassert_equal(0, flash_area_copy(fa_src, src_offset, fa_dst, dst_offset, copy_len,
+					 flash_copy_buffer, sizeof(flash_copy_buffer)));
 
 	flash_area_close(fa_dst);
 	flash_area_close(fa_src);
@@ -433,12 +539,21 @@ struct patch_file {
 	uint8_t patch[5];
 } __packed hardcoded_patch;
 
+#define CPATCH_TAIL_WRITE_LEN 64
+
+struct patch_tail_file {
+	struct cpatch_header header;
+	uint8_t patch[10 + CPATCH_TAIL_WRITE_LEN];
+} __packed hardcoded_tail_patch;
+
 #if PARTITION_EXISTS(file_partition)
 ZTEST(rpc_command_file_write_basic, test_file_write_dfu_cpatch)
 {
 	const struct device *slot0_dev = PARTITION_DEVICE(slot0_partition);
 	const struct device *slot1_dev = PARTITION_DEVICE(slot1_partition);
 	struct test_out ret;
+	off_t slot0_offset = boot_get_image_start_offset(PARTITION_ID(slot0_partition));
+	off_t slot1_offset = boot_get_image_start_offset(PARTITION_ID(slot1_partition));
 
 	zassert_device_released(slot0_dev);
 	zassert_device_released(slot1_dev);
@@ -452,8 +567,8 @@ ZTEST(rpc_command_file_write_basic, test_file_write_dfu_cpatch)
 	validate_flash_area(&ret, PARTITION_ID(slot1_partition));
 
 	/* Copy the base image into partition0 and erase partition1 */
-	flash_area_copy_wrapped(PARTITION_ID(slot0_partition), PARTITION_ID(slot1_partition), 17023,
-				true);
+	flash_area_copy_wrapped(PARTITION_ID(slot0_partition), slot0_offset,
+				PARTITION_ID(slot1_partition), slot1_offset, 17023, true);
 
 	/* Construct patch file that just regenerates the original file */
 	hardcoded_patch.patch[0] = 48; /* COPY_LEN_U32 */
@@ -488,8 +603,9 @@ ZTEST(rpc_command_file_write_basic, test_file_write_dfu_cpatch)
 	uint32_t fa_crc;
 
 	zassert_equal(0, flash_area_open(PARTITION_ID(slot1_partition), &fa));
-	zassert_equal(0, flash_area_crc32(fa, 0, hardcoded_patch.header.output_file.length, &fa_crc,
-					  buffer, sizeof(buffer)));
+	zassert_equal(0,
+		      flash_area_crc32(fa, slot1_offset, hardcoded_patch.header.output_file.length,
+				       &fa_crc, buffer, sizeof(buffer)));
 	zassert_equal(hardcoded_patch.header.output_file.crc, fa_crc,
 		      "CRC constructed does not equal original CRC");
 	flash_area_close(fa);
@@ -510,12 +626,98 @@ ZTEST(rpc_command_file_write_basic, test_file_write_dfu_cpatch)
 	zassert_device_released(slot1_dev);
 }
 
+ZTEST(rpc_command_file_write_basic, test_file_write_dfu_cpatch_slot1_offset_erase)
+{
+	const struct device *slot0_dev = PARTITION_DEVICE(slot0_partition);
+	const struct device *slot1_dev = PARTITION_DEVICE(slot1_partition);
+	struct test_out ret;
+	off_t slot0_offset = boot_get_image_start_offset(PARTITION_ID(slot0_partition));
+	off_t slot1_offset = boot_get_image_start_offset(PARTITION_ID(slot1_partition));
+
+	zassert_device_released(slot0_dev);
+	zassert_device_released(slot1_dev);
+
+	/* Write a known image to partition1 */
+	ret = test_file_write_basic(RPC_ENUM_FILE_ACTION_APP_IMG, sizeof(cpatch_payload), 0, 0, 0,
+				    0, false, false, cpatch_payload);
+	zassert_equal(0, ret.cmd_rc);
+	zassert_equal(sizeof(cpatch_payload), ret.cmd_len);
+	zassert_equal(ret.written_crc, ret.cmd_crc);
+	validate_flash_area(&ret, PARTITION_ID(slot1_partition));
+
+	/* Copy the base image into partition0 and erase partition1 */
+	flash_area_copy_wrapped(PARTITION_ID(slot0_partition), slot0_offset,
+				PARTITION_ID(slot1_partition), slot1_offset, sizeof(cpatch_payload),
+				true);
+
+	/* Copy the input, then change the tail so stale slot1 data cannot mask under-erase. */
+	hardcoded_tail_patch.patch[0] = 48; /* COPY_LEN_U32 */
+	sys_put_le32(sizeof(cpatch_payload) - CPATCH_TAIL_WRITE_LEN,
+		     hardcoded_tail_patch.patch + 1);
+	hardcoded_tail_patch.patch[5] = 112; /* WRITE_LEN_U32 */
+	sys_put_le32(CPATCH_TAIL_WRITE_LEN, hardcoded_tail_patch.patch + 6);
+	memset(hardcoded_tail_patch.patch + 10, 0xA5, CPATCH_TAIL_WRITE_LEN);
+
+	uint32_t output_crc =
+		crc32_ieee(cpatch_payload, sizeof(cpatch_payload) - CPATCH_TAIL_WRITE_LEN);
+
+	output_crc = crc32_ieee_update(output_crc, hardcoded_tail_patch.patch + 10,
+				       CPATCH_TAIL_WRITE_LEN);
+
+	hardcoded_tail_patch.header.magic_value = CPATCH_MAGIC_NUMBER;
+	hardcoded_tail_patch.header.version_major = 1;
+	hardcoded_tail_patch.header.version_minor = 0;
+	hardcoded_tail_patch.header.input_file.length = sizeof(cpatch_payload);
+	hardcoded_tail_patch.header.input_file.crc = ret.written_crc;
+	hardcoded_tail_patch.header.output_file.length = sizeof(cpatch_payload);
+	hardcoded_tail_patch.header.output_file.crc = output_crc;
+	hardcoded_tail_patch.header.patch_file.length = sizeof(hardcoded_tail_patch.patch);
+	hardcoded_tail_patch.header.patch_file.crc =
+		crc32_ieee(hardcoded_tail_patch.patch, sizeof(hardcoded_tail_patch.patch));
+	hardcoded_tail_patch.header.header_crc =
+		crc32_ieee((const void *)&hardcoded_tail_patch.header,
+			   sizeof(hardcoded_tail_patch.header) - sizeof(uint32_t));
+
+	/* Write the patch file */
+	ret = test_file_write_basic(RPC_ENUM_FILE_ACTION_APP_CPATCH, sizeof(hardcoded_tail_patch),
+				    0, 0, 0, 0, false, false, &hardcoded_tail_patch);
+	zassert_equal(0, ret.cmd_rc);
+	zassert_equal(sizeof(hardcoded_tail_patch), ret.cmd_len);
+	zassert_equal(ret.written_crc, ret.cmd_crc);
+
+	/* Give command a chance to finish writing the patch */
+	k_sleep(K_MSEC(100));
+
+	uint8_t buffer[128];
+	const struct flash_area *fa;
+	uint32_t fa_crc;
+
+	zassert_equal(0, flash_area_open(PARTITION_ID(slot1_partition), &fa));
+	zassert_equal(0, flash_area_crc32(fa, slot1_offset,
+					  hardcoded_tail_patch.header.output_file.length, &fa_crc,
+					  buffer, sizeof(buffer)));
+	zassert_equal(hardcoded_tail_patch.header.output_file.crc, fa_crc,
+		      "CRC constructed does not equal patched output CRC");
+	flash_area_close(fa);
+
+	/* Balanced call count */
+	zassert_equal(0, infuse_dfu_write_erase_call_count());
+
+	zassert_device_released(slot0_dev);
+	zassert_device_released(slot1_dev);
+}
+
 #else
 
 ZTEST(rpc_command_file_write_basic, test_file_write_dfu_cpatch)
 {
 	(void)flash_area_copy_wrapped;
 
+	ztest_test_skip();
+}
+
+ZTEST(rpc_command_file_write_basic, test_file_write_dfu_cpatch_slot1_offset_erase)
+{
 	ztest_test_skip();
 }
 
@@ -793,6 +995,7 @@ void *file_write_basic_setup(void)
 {
 	sys_rand_get(fixed_payload, sizeof(fixed_payload));
 	fixed_payload_crc = crc32_ieee(fixed_payload, sizeof(fixed_payload));
+	sys_rand_get(cpatch_payload, sizeof(cpatch_payload));
 
 #ifdef CONFIG_INFUSE_LITTLEFS
 	(void)infuse_littlefs_init();

--- a/tests/subsys/rpc/commands/file_write_basic/testcase.yaml
+++ b/tests/subsys/rpc/commands/file_write_basic/testcase.yaml
@@ -30,6 +30,18 @@ tests:
     extra_configs:
       - CONFIG_INFUSE_RPC_COMMON_FILE_ACTIONS_WRITE_BUFFER=1024
       - CONFIG_INFUSE_RPC_SERVER_WORKING_MEMORY=1024
+  rpc.commands.file_write_basic.native.mcuboot_offset:
+    platform_allow:
+      - native_sim
+    integration_platforms:
+      - native_sim
+    extra_args:
+      - DTC_OVERLAY_FILE="./boards/native_sim.overlay;./mcuboot_offset.overlay"
+    extra_configs:
+      - CONFIG_BOOTLOADER_MCUBOOT=y
+      - CONFIG_IMG_MANAGER=y
+      - CONFIG_MCUBOOT_IMG_MANAGER=y
+      - CONFIG_MCUBOOT_BOOTLOADER_MODE_SWAP_USING_OFFSET=y
   # FILE_WRITE should behave the same way as FILE_WRITE_BASIC
   # for the non-filesystem actions
   rpc.commands.file_write_basic.fw:


### PR DESCRIPTION
Fix several erase edge cases in the common file actions handling when `SWAP_USING_OFFSET` is enabled.
The bugs did not cause issues on any deployed applications, as `SWAP_USING_OFFSET` is only enabled by default for platforms that don't require flash erase before write, e.g. nRF54L.
These updates make the implementation technically correct, and therefore compatible with general flash storage.