### PR TITLE
lib: modem_monitor: logging of sleep states

### DIFF
--- a/apps/gateway_lte/src/main.c
+++ b/apps/gateway_lte/src/main.c
@@ -324,6 +324,9 @@ int main(void)
 	struct kv_store_cb kv_cb = {
 		.value_changed = kv_value_changed,
 	};
+	struct lte_modem_monitor_config modem_monitor_config = {
+		.conn_status_logger_mask = TDF_DATA_LOGGER_FLASH,
+	};
 	struct lte_modem_network_state lte_state;
 	uint16_t udp_payload_size;
 	bool lte_modem_active;
@@ -371,7 +374,7 @@ int main(void)
 	tdf_reboot_info_log(TDF_DATA_LOGGER_FLASH | TDF_DATA_LOGGER_BT_ADV | TDF_DATA_LOGGER_UDP);
 
 	/* Log LTE connection events */
-	lte_modem_monitor_network_state_log(TDF_DATA_LOGGER_FLASH);
+	lte_modem_monitor_configure(&modem_monitor_config);
 
 	/* Configure time event logging */
 	auto_time_sync_log_configure(TDF_DATA_LOGGER_FLASH,

--- a/generated/include/infuse/tdf/definitions.h
+++ b/generated/include/infuse/tdf/definitions.h
@@ -790,6 +790,20 @@ struct tdf_lte_control {
 	uint8_t enabled;
 } __packed;
 
+/** LTE modem has entered sleep mode */
+struct tdf_lte_sleep_enter {
+	/** Type of sleep mode that exited (Values from lte_lc_modem_sleep_type) */
+	uint8_t type;
+} __packed;
+
+/** LTE modem has exited sleep mode */
+struct tdf_lte_sleep_exit {
+	/** Type of sleep mode that exited (Values from lte_lc_modem_sleep_type) */
+	uint8_t type;
+	/** How long modem was in sleep mode for in seconds */
+	uint32_t duration_s;
+} __packed;
+
 /** Infuse-IoT builtin TDF definitions */
 enum tdf_builtin_id {
 	/** Common announcement packet */
@@ -916,6 +930,10 @@ enum tdf_builtin_id {
 	TDF_AMBIENT_PRESSURE = 62,
 	/** LTE modem control state */
 	TDF_LTE_CONTROL = 63,
+	/** LTE modem has entered sleep mode */
+	TDF_LTE_SLEEP_ENTER = 64,
+	/** LTE modem has exited sleep mode */
+	TDF_LTE_SLEEP_EXIT = 65,
 	/** End of builtin TDF range */
 	TDF_BUILTIN_END = 1024,
 };
@@ -982,6 +1000,8 @@ enum tdf_builtin_id {
 #define _TDF_KVS_VALUE_CHANGED_TYPE           struct tdf_kvs_value_changed
 #define _TDF_AMBIENT_PRESSURE_TYPE            struct tdf_ambient_pressure
 #define _TDF_LTE_CONTROL_TYPE                 struct tdf_lte_control
+#define _TDF_LTE_SLEEP_ENTER_TYPE             struct tdf_lte_sleep_enter
+#define _TDF_LTE_SLEEP_EXIT_TYPE              struct tdf_lte_sleep_exit
 
 /** Size of builtin TDF definitions */
 enum tdf_builtin_size {
@@ -1045,6 +1065,8 @@ enum tdf_builtin_size {
 	_TDF_KVS_VALUE_CHANGED_SIZE = sizeof(struct tdf_kvs_value_changed),
 	_TDF_AMBIENT_PRESSURE_SIZE = sizeof(struct tdf_ambient_pressure),
 	_TDF_LTE_CONTROL_SIZE = sizeof(struct tdf_lte_control),
+	_TDF_LTE_SLEEP_ENTER_SIZE = sizeof(struct tdf_lte_sleep_enter),
+	_TDF_LTE_SLEEP_EXIT_SIZE = sizeof(struct tdf_lte_sleep_exit),
 };
 
 /** @endcond */

--- a/include/infuse/lib/lte_modem_monitor.h
+++ b/include/infuse/lib/lte_modem_monitor.h
@@ -112,6 +112,19 @@ struct lte_modem_network_state {
 	uint8_t cp_rai;
 };
 
+/** Configuration options for the modem monitor */
+struct lte_modem_monitor_config {
+	/** TDF data logger mask to log @ref TDF_LTE_CONN_STATUS to */
+	uint8_t conn_status_logger_mask;
+};
+
+/**
+ * @brief Configure the modem monitor
+ *
+ * @param config Configuration options
+ */
+void lte_modem_monitor_configure(const struct lte_modem_monitor_config *config);
+
 /**
  * @brief Query whether it is currently safe to send AT commands
  *
@@ -140,15 +153,6 @@ bool lte_modem_monitor_is_registered(void);
  * @param state Network state
  */
 void lte_modem_monitor_network_state(struct lte_modem_network_state *state);
-
-/**
- * @brief Configure the modem monitor to automatically log network state changes
- *
- * Logs @ref TDF_LTE_CONN_STATUS on registration status and cell changes.
- *
- * @param tdf_logger_mask TDF data logger mask to log state changes to
- */
-void lte_modem_monitor_network_state_log(uint8_t tdf_logger_mask);
 
 /**
  * @brief Get current signal quality

--- a/include/infuse/lib/lte_modem_monitor.h
+++ b/include/infuse/lib/lte_modem_monitor.h
@@ -116,6 +116,10 @@ struct lte_modem_network_state {
 struct lte_modem_monitor_config {
 	/** TDF data logger mask to log @ref TDF_LTE_CONN_STATUS to */
 	uint8_t conn_status_logger_mask;
+	/** TDF data logger mask to log @ref TDF_LTE_SLEEP_ENTER to */
+	uint8_t sleep_mode_enter_logger_mask;
+	/** TDF data logger mask to log @ref TDF_LTE_SLEEP_EXIT to */
+	uint8_t sleep_mode_exit_logger_mask;
 };
 
 /**

--- a/lib/modem_monitor/Kconfig
+++ b/lib/modem_monitor/Kconfig
@@ -16,7 +16,7 @@ config INFUSE_MODEM_MONITOR_CONN_STATE_LOG
 	help
 	  Automatically log TDF_LTE_CONN_STATUS TDFs in response to registration
 	  state and cell tower changes. Output loggers must be configured with
-	  `lte_modem_monitor_network_state_log`.
+	  `lte_modem_monitor_configure`.
 
 config INFUSE_MODEM_MONITOR_CONNECTIVITY_TIMEOUT_SEC
 	int "Timeout for receiving L4 connectivity after registering on the network"

--- a/lib/modem_monitor/Kconfig
+++ b/lib/modem_monitor/Kconfig
@@ -10,12 +10,12 @@ module-str = modem_mon
 source "subsys/logging/Kconfig.template.log_config"
 
 config INFUSE_MODEM_MONITOR_CONN_STATE_LOG
-	bool "Automatic logging of LTE connection state"
+	bool "Automatic logging of LTE connection events"
 	depends on INFUSE_EPOCH_TIME
 	depends on TDF_DATA_LOGGER
 	help
-	  Automatically log TDF_LTE_CONN_STATUS TDFs in response to registration
-	  state and cell tower changes. Output loggers must be configured with
+	  Automatically log TDFs in response to registration state, cell tower
+	  and sleep state changes. Output loggers must be configured with
 	  `lte_modem_monitor_configure`.
 
 config INFUSE_MODEM_MONITOR_CONNECTIVITY_TIMEOUT_SEC

--- a/lib/modem_monitor/modem_cellular/cellular_modem_monitor.c
+++ b/lib/modem_monitor/modem_cellular/cellular_modem_monitor.c
@@ -29,7 +29,7 @@ static struct {
 	struct lte_modem_network_state network_state;
 	struct kv_store_cb lte_kv_cb;
 #ifdef CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG
-	uint8_t network_state_loggers;
+	uint8_t conn_status_loggers;
 #endif /* CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG */
 	struct k_work_delayable shutdown_fallback;
 	bool at_link_dead;
@@ -49,12 +49,14 @@ bool lte_modem_monitor_is_registered(void)
 	       (status == CELLULAR_REGISTRATION_REGISTERED_ROAMING);
 }
 
-#ifdef CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG
-void lte_modem_monitor_network_state_log(uint8_t tdf_logger_mask)
+void lte_modem_monitor_configure(const struct lte_modem_monitor_config *config)
 {
-	monitor.network_state_loggers = tdf_logger_mask;
-}
+#ifdef CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG
+	monitor.conn_status_loggers = config->conn_status_logger_mask;
+#else
+	ARG_UNUSED(config);
 #endif /* CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG */
+}
 
 int lte_modem_monitor_signal_quality(int16_t *rsrp, int8_t *rsrq, bool cached)
 {

--- a/lib/modem_monitor/modem_nrf9x/nrf_modem_monitor.c
+++ b/lib/modem_monitor/modem_nrf9x/nrf_modem_monitor.c
@@ -88,7 +88,7 @@ static struct {
 	int16_t rsrp_cached;
 	int8_t rsrq_cached;
 #ifdef CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG
-	uint8_t network_state_loggers;
+	uint8_t conn_status_loggers;
 #endif /* CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG */
 } monitor;
 
@@ -123,12 +123,14 @@ bool lte_modem_monitor_is_at_safe(void)
 #endif /* CONFIG_SOC_NRF9160 */
 }
 
-#ifdef CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG
-void lte_modem_monitor_network_state_log(uint8_t tdf_logger_mask)
+void lte_modem_monitor_configure(const struct lte_modem_monitor_config *config)
 {
-	monitor.network_state_loggers = tdf_logger_mask;
-}
+#ifdef CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG
+	monitor.conn_status_loggers = config->conn_status_logger_mask;
+#else
+	ARG_UNUSED(config);
 #endif /* CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG */
+}
 
 bool lte_modem_monitor_is_registered(void)
 {
@@ -252,7 +254,7 @@ static void network_info_update(struct k_work *work)
 
 state_logging:
 #ifdef CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG
-	if (monitor.network_state_loggers) {
+	if (monitor.conn_status_loggers) {
 		struct tdf_lte_conn_status tdf;
 		int16_t rsrp;
 		int8_t rsrq;
@@ -262,7 +264,7 @@ state_logging:
 		/* Convert to TDF */
 		tdf_lte_conn_status_from_monitor(&monitor.network_state, &tdf, rsrp, rsrq);
 		/* Add to specified loggers */
-		TDF_DATA_LOGGER_LOG(monitor.network_state_loggers, TDF_LTE_CONN_STATUS,
+		TDF_DATA_LOGGER_LOG(monitor.conn_status_loggers, TDF_LTE_CONN_STATUS,
 				    epoch_time_now(), &tdf);
 	}
 #endif /* CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG */

--- a/lib/modem_monitor/modem_nrf9x/nrf_modem_monitor.c
+++ b/lib/modem_monitor/modem_nrf9x/nrf_modem_monitor.c
@@ -88,6 +88,9 @@ static struct {
 	int16_t rsrp_cached;
 	int8_t rsrq_cached;
 #ifdef CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG
+	k_ticks_t sleep_enter_time;
+	uint8_t sleep_enter_loggers;
+	uint8_t sleep_exit_loggers;
 	uint8_t conn_status_loggers;
 #endif /* CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG */
 } monitor;
@@ -127,6 +130,8 @@ void lte_modem_monitor_configure(const struct lte_modem_monitor_config *config)
 {
 #ifdef CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG
 	monitor.conn_status_loggers = config->conn_status_logger_mask;
+	monitor.sleep_enter_loggers = config->sleep_mode_enter_logger_mask;
+	monitor.sleep_exit_loggers = config->sleep_mode_exit_logger_mask;
 #else
 	ARG_UNUSED(config);
 #endif /* CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG */
@@ -414,11 +419,34 @@ static void lte_reg_handler(const struct lte_lc_evt *const evt)
 		LOG_DBG("    Type: %d", evt->modem_sleep.type);
 		LOG_DBG("     Dur: %lld", evt->modem_sleep.time);
 		atomic_set_bit(&monitor.flags, FLAGS_MODEM_SLEEPING);
+#ifdef CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG
+		monitor.sleep_enter_time = k_uptime_ticks();
+		{
+			struct tdf_lte_sleep_enter tdf = {
+				.type = evt->modem_sleep.type,
+			};
+
+			TDF_DATA_LOGGER_LOG(monitor.sleep_enter_loggers, TDF_LTE_SLEEP_ENTER,
+					    epoch_time_now(), &tdf);
+		}
+#endif /* CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG */
 		break;
 	case LTE_LC_EVT_MODEM_SLEEP_EXIT:
 		LOG_DBG("MODEM_SLEEP_EXIT");
 		LOG_DBG("    Type: %d", evt->modem_sleep.type);
 		atomic_clear_bit(&monitor.flags, FLAGS_MODEM_SLEEPING);
+#ifdef CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG
+		{
+			struct tdf_lte_sleep_exit tdf = {
+				.type = evt->modem_sleep.type,
+				.duration_s = k_ticks_to_sec_floor32(k_uptime_ticks() -
+								     monitor.sleep_enter_time),
+			};
+
+			TDF_DATA_LOGGER_LOG(monitor.sleep_exit_loggers, TDF_LTE_SLEEP_EXIT,
+					    epoch_time_now(), &tdf);
+		}
+#endif /* CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG */
 		break;
 	case LTE_LC_EVT_MODEM_EVENT:
 		LOG_DBG("MODEM_EVENT");

--- a/scripts/west_commands/cloud_definitions/tdf.json
+++ b/scripts/west_commands/cloud_definitions/tdf.json
@@ -628,6 +628,21 @@
             "fields": [
                 {"name": "enabled", "type": "uint8_t", "description": "0 is disabled, 1 is enabled"}
             ]
+        },
+        "64": {
+            "name": "LTE_SLEEP_ENTER",
+            "description": "LTE modem has entered sleep mode",
+            "fields": [
+                {"name": "type", "type": "uint8_t", "description": "Type of sleep mode that started (Values from lte_lc_modem_sleep_type)"}
+            ]
+        },
+        "65": {
+            "name": "LTE_SLEEP_EXIT",
+            "description": "LTE modem has exited sleep mode",
+            "fields": [
+                {"name": "type", "type": "uint8_t", "description": "Type of sleep mode that exited (Values from lte_lc_modem_sleep_type)"},
+                {"name": "duration_s", "type": "uint32_t", "description": "How long modem was in sleep mode for in seconds"}
+            ]
         }
     }
 }

--- a/tests/net/nrf_modem_lib/src/main.c
+++ b/tests/net/nrf_modem_lib/src/main.c
@@ -168,21 +168,25 @@ ZTEST(infuse_nrf_modem_monitor, test_integration)
 	int rc;
 
 #ifdef CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG
-	struct tdf_lte_conn_status *lte_conn_status;
 	struct k_fifo *tx_fifo = epacket_dummmy_transmit_fifo_get();
 	struct lte_modem_monitor_config modem_monitor_config = {
 		.conn_status_logger_mask = TDF_DATA_LOGGER_SERIAL,
+		.sleep_mode_enter_logger_mask = TDF_DATA_LOGGER_SERIAL,
+		.sleep_mode_exit_logger_mask = TDF_DATA_LOGGER_SERIAL,
 	};
 	struct tdf_parsed tdf;
 	struct net_buf *tx;
+	struct tdf_lte_conn_status *lte_conn_status;
+	struct tdf_lte_sleep_enter *sleep_enter;
+	struct tdf_lte_sleep_exit *sleep_exit;
 
 	zassert_not_null(tx_fifo);
 	tx = k_fifo_get(tx_fifo, K_MSEC(100));
 	zassert_is_null(tx);
 
-	/* Enable conn status logging */
+	/* Enable LTE state logging */
 	lte_modem_monitor_configure(&modem_monitor_config);
-#endif
+#endif /* CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG */
 
 	zassert_false(kv_store_key_exists(KV_KEY_LTE_MODEM_MODEL));
 	zassert_false(kv_store_key_exists(KV_KEY_LTE_MODEM_FIRMWARE_REVISION));
@@ -407,6 +411,17 @@ ZTEST(infuse_nrf_modem_monitor, test_integration)
 	nrf_modem_lib_sim_send_at("%XMODEMSLEEP: 1,46783975\r\n");
 	k_sleep(K_SECONDS(10));
 
+#ifdef CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG
+	tdf_data_logger_flush(TDF_DATA_LOGGER_SERIAL);
+	tx = k_fifo_get(tx_fifo, K_MSEC(100));
+	zassert_not_null(tx);
+	net_buf_pull(tx, sizeof(struct epacket_dummy_frame));
+	zassert_equal(0, tdf_parse_find_in_buf(tx->data, tx->len, TDF_LTE_SLEEP_ENTER, &tdf));
+	sleep_enter = tdf.data;
+	zassert_equal(LTE_LC_MODEM_SLEEP_PSM, sleep_enter->type);
+	net_buf_unref(tx);
+#endif /* CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG */
+
 	nrf_modem_lib_sim_signal_strength(10, 40);
 	rc = lte_modem_monitor_signal_quality(&rsrp, &rsrq, false);
 	zassert_equal(0, rc);
@@ -421,6 +436,22 @@ ZTEST(infuse_nrf_modem_monitor, test_integration)
 	zassert_equal(0, rc);
 	zassert_equal(-101, rsrp);
 	zassert_equal(-15, rsrq);
+
+#ifdef CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG
+	tdf_data_logger_flush(TDF_DATA_LOGGER_SERIAL);
+	tx = k_fifo_get(tx_fifo, K_MSEC(100));
+	zassert_not_null(tx);
+	net_buf_pull(tx, sizeof(struct epacket_dummy_frame));
+	zassert_equal(0, tdf_parse_find_in_buf(tx->data, tx->len, TDF_LTE_SLEEP_EXIT, &tdf));
+	sleep_exit = tdf.data;
+	zassert_equal(LTE_LC_MODEM_SLEEP_PSM, sleep_exit->type);
+	zassert_within(10, sleep_exit->duration_s, 1);
+	net_buf_unref(tx);
+
+	modem_monitor_config.sleep_mode_enter_logger_mask = 0;
+	modem_monitor_config.sleep_mode_exit_logger_mask = 0;
+	lte_modem_monitor_configure(&modem_monitor_config);
+#endif /* CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG */
 
 	/* IP connectivity goes down, reboot should be requested */
 	zassert_true(net_if_ipv4_addr_rm(iface, (struct in_addr *)&ipv4_addr));

--- a/tests/net/nrf_modem_lib/src/main.c
+++ b/tests/net/nrf_modem_lib/src/main.c
@@ -163,6 +163,8 @@ ZTEST(infuse_nrf_modem_monitor, test_integration)
 	enum lte_lc_pdn_family default_family;
 	const char *default_apn;
 	struct net_if_addr *added;
+	int16_t rsrp;
+	int8_t rsrq;
 	int rc;
 
 #ifdef CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG
@@ -405,8 +407,21 @@ ZTEST(infuse_nrf_modem_monitor, test_integration)
 	nrf_modem_lib_sim_send_at("%XMODEMSLEEP: 1,46783975\r\n");
 	k_sleep(K_SECONDS(10));
 
+	nrf_modem_lib_sim_signal_strength(10, 40);
+	rc = lte_modem_monitor_signal_quality(&rsrp, &rsrq, false);
+	zassert_equal(0, rc);
+	zassert_equal(INT16_MIN, rsrp);
+	zassert_equal(INT8_MIN, rsrq);
+
 	/* Modem wakes */
 	nrf_modem_lib_sim_send_at("%XMODEMSLEEP: 1,0\r\n");
+	k_sleep(K_MSEC(10));
+
+	rc = lte_modem_monitor_signal_quality(&rsrp, &rsrq, false);
+	zassert_equal(0, rc);
+	zassert_equal(-101, rsrp);
+	zassert_equal(-15, rsrq);
+
 	/* IP connectivity goes down, reboot should be requested */
 	zassert_true(net_if_ipv4_addr_rm(iface, (struct in_addr *)&ipv4_addr));
 	rc = k_sem_take(&reboot_request,

--- a/tests/net/nrf_modem_lib/src/main.c
+++ b/tests/net/nrf_modem_lib/src/main.c
@@ -168,6 +168,9 @@ ZTEST(infuse_nrf_modem_monitor, test_integration)
 #ifdef CONFIG_INFUSE_MODEM_MONITOR_CONN_STATE_LOG
 	struct tdf_lte_conn_status *lte_conn_status;
 	struct k_fifo *tx_fifo = epacket_dummmy_transmit_fifo_get();
+	struct lte_modem_monitor_config modem_monitor_config = {
+		.conn_status_logger_mask = TDF_DATA_LOGGER_SERIAL,
+	};
 	struct tdf_parsed tdf;
 	struct net_buf *tx;
 
@@ -176,7 +179,7 @@ ZTEST(infuse_nrf_modem_monitor, test_integration)
 	zassert_is_null(tx);
 
 	/* Enable conn status logging */
-	lte_modem_monitor_network_state_log(TDF_DATA_LOGGER_SERIAL);
+	lte_modem_monitor_configure(&modem_monitor_config);
 #endif
 
 	zassert_false(kv_store_key_exists(KV_KEY_LTE_MODEM_MODEL));
@@ -350,7 +353,8 @@ ZTEST(infuse_nrf_modem_monitor, test_integration)
 	net_buf_unref(tx);
 
 	/* Disable conn status logging */
-	lte_modem_monitor_network_state_log(0);
+	modem_monitor_config.conn_status_logger_mask = 0;
+	lte_modem_monitor_configure(&modem_monitor_config);
 #endif
 
 	/* Back on the network, gain network connectivity this time */


### PR DESCRIPTION
Add optional TDF logging of sleep states to the modem monitor API. The implementation is currently Nordic only, as the Zephyr cellular modem API does not expose sleep events.