### PR TITLE
manifest: update zephyr fork

### DIFF
--- a/subsys/rpc/commands/lte_at_cmd_modem.c
+++ b/subsys/rpc/commands/lte_at_cmd_modem.c
@@ -13,7 +13,7 @@
 #include <zephyr/modem/at/user_pipe.h>
 
 static struct modem_chat modem_chat_ctx;
-static uint8_t lte_at_chat_receive_buf[128];
+static uint8_t lte_at_chat_receive_buf[CONFIG_MODEM_CELLULAR_USER_PIPE_BUFFER_SIZES];
 static uint8_t *lte_at_chat_argv_buf[2];
 struct ctx {
 	char *buf;

--- a/subsys/rpc/commands/lte_at_cmd_modem.c
+++ b/subsys/rpc/commands/lte_at_cmd_modem.c
@@ -98,13 +98,14 @@ int cellular_modem_at_cmd(void *buf, size_t len, const char *cmd)
 
 	modem_chat_script_chat_init(&chat_single);
 	modem_chat_script_chat_set_request(&chat_single, cmd);
-	modem_chat_script_chat_set_response_matches(&chat_single, chat_matches, 2);
+	modem_chat_script_chat_set_response_matches(&chat_single, chat_matches,
+						    ARRAY_SIZE(chat_matches));
 	modem_chat_script_chat_set_timeout(&chat_single, 2000);
 
 	modem_chat_script_init(&script);
 	modem_chat_script_set_script_chats(&script, &chat_single, 1);
 	modem_chat_script_set_callback(&script, script_done_cb);
-	modem_chat_script_set_abort_matches(&script, abort_matches, 1);
+	modem_chat_script_set_abort_matches(&script, abort_matches, ARRAY_SIZE(abort_matches));
 	modem_chat_script_set_timeout(&script, 2);
 
 	cmd_ctx.rc = modem_at_user_pipe_claim(&modem_chat_ctx, K_MSEC(200));

--- a/west.yml
+++ b/west.yml
@@ -16,7 +16,7 @@ manifest:
 
   projects:
     - name: zephyr
-      revision: b8561df75b1953e0be452b078d1db2a35ef5446b
+      revision: 41ffc7ece83d8ee916fd8c9a6d7e3101567ce654
       # Limit imported repositories to reduce clone time
       import:
         name-allowlist:


### PR DESCRIPTION
Update zephyr fork to fix the nRF93M1 driver requesting an insufficient CMUX MTU.