### PR TITLE
modem: backends: u_blox: handle data ready asserted out of sleep

### DIFF
--- a/drivers/gnss/gnss_u_blox_m10_i2c.c
+++ b/drivers/gnss/gnss_u_blox_m10_i2c.c
@@ -443,7 +443,9 @@ static int ubx_m10_i2c_software_standby(const struct device *dev)
 static int ubx_m10_i2c_software_resume(const struct device *dev)
 {
 	NET_BUF_SIMPLE_DEFINE(cfg_buf, 64);
+	const struct ubx_m10_i2c_config *cfg = dev->config;
 	struct ubx_m10_i2c_data *data = dev->data;
+	int data_ready;
 	int rc = 0;
 
 	/* Wait until modem is ready to wake */
@@ -451,6 +453,17 @@ static int ubx_m10_i2c_software_resume(const struct device *dev)
 
 	/* Wake by generating an edge on the EXTINT pin */
 	ubx_common_extint_wake(dev);
+
+	/* Handle data ready already being asserted out of sleep.
+	 * Defensive programming as opposed to an observed behavioural mode.
+	 */
+	data_ready = gpio_pin_get_dt(&cfg->common.data_ready_gpio);
+	if (data_ready > 0) {
+		LOG_DBG("Data-ready asserted after wake");
+		k_work_reschedule(&data->i2c_backend.common.fifo_read, K_NO_WAIT);
+	} else if (data_ready < 0) {
+		LOG_WRN("Failed to read data-ready GPIO (%d)", data_ready);
+	}
 
 	/* Ublox-M10 apparently does not output MON-RXR on wake, despite the M10 interface
 	 * description saying it does. This is a confirmed bug with the I2C interface.

--- a/drivers/gnss/gnss_u_blox_m8_spi.c
+++ b/drivers/gnss/gnss_u_blox_m8_spi.c
@@ -402,12 +402,14 @@ static int ubx_m8_spi_software_standby(const struct device *dev)
 
 static int ubx_m8_spi_software_resume(const struct device *dev)
 {
+	const struct ubx_m8_spi_config *cfg = dev->config;
 	struct ubx_m8_spi_data *data = dev->data;
 	struct k_poll_event mon_rxr_events[] = {
 		K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY,
 					 &data->common.mon_rxr_signal),
 	};
 	unsigned int signaled;
+	int data_ready;
 	int result;
 	int rc;
 
@@ -419,6 +421,17 @@ static int ubx_m8_spi_software_resume(const struct device *dev)
 
 	/* Wake by generating an edge on the EXTINT pin */
 	ubx_common_extint_wake(dev);
+
+	/* Handle data ready already being asserted out of sleep.
+	 * Defensive programming as opposed to an observed behavioural mode.
+	 */
+	data_ready = gpio_pin_get_dt(&cfg->common.data_ready_gpio);
+	if (data_ready > 0) {
+		LOG_DBG("Data-ready asserted after wake");
+		k_work_reschedule(&data->spi_backend.common.fifo_read, K_NO_WAIT);
+	} else if (data_ready < 0) {
+		LOG_WRN("Failed to read data-ready GPIO (%d)", data_ready);
+	}
 
 	/* Wait for the expected MON-RXR message */
 	rc = k_poll(mon_rxr_events, ARRAY_SIZE(mon_rxr_events), SYNC_MESSAGE_TIMEOUT);

--- a/subsys/modem/backends/modem_backend_u_blox_i2c.c
+++ b/subsys/modem/backends/modem_backend_u_blox_i2c.c
@@ -235,6 +235,11 @@ static void fifo_read_start(struct k_work *work)
 	rc = rtio_submit(&i2c_rtio, 0);
 	if (rc < 0) {
 		LOG_ERR("Failed to submit RTIO (%d)", rc);
+		/* Release resources */
+		k_sem_give(&backend->common.bus_sem);
+		pm_device_runtime_put(backend->i2c->bus);
+		rtio_sqe_drop_all(&i2c_rtio);
+		/* Try again after a short delay */
 		k_work_reschedule(dwork, K_MSEC(100));
 	}
 }
@@ -312,6 +317,12 @@ static int modem_backend_ublox_i2c_transmit_double(void *data, const uint8_t *bu
 
 	/* Submit TX work */
 	rc = rtio_submit(&i2c_rtio, 0);
+	if (rc < 0) {
+		/* Release resources, as `write_cb` will not run */
+		k_sem_give(&backend->common.bus_sem);
+		pm_device_runtime_put(backend->i2c->bus);
+		rtio_sqe_drop_all(&i2c_rtio);
+	}
 	return rc == 0 ? size : rc;
 }
 

--- a/subsys/modem/backends/modem_backend_u_blox_spi.c
+++ b/subsys/modem/backends/modem_backend_u_blox_spi.c
@@ -206,6 +206,12 @@ static int modem_backend_ublox_spi_transmit_double(void *data, const uint8_t *bu
 			       backend);
 	if (rc < 0) {
 		LOG_ERR("FIFO read trigger failed");
+		/* Release resources */
+		k_sem_give(&backend->common.bus_sem);
+#ifdef CONFIG_MODEM_BACKEND_U_BLOX_SPI_PM_MODE_BURST
+		pm_device_runtime_put(backend->spi->bus);
+
+#endif
 		return rc;
 	}
 	return total_size;


### PR DESCRIPTION
Handle the possible edge case of the data-ready pin already being asserted as we leave sleep. If this were true, our trigger to read the FIFO would never occur.

Fix the u_blox modem backend handling when an `rtio_submit` call fails. This should not be possible in practice.