### PR TITLE
bluetooth: assert_handler: catch MPSL assertions

### DIFF
--- a/include/infuse/lib/memfault_config/memfault_trace_reason_user_config.def
+++ b/include/infuse/lib/memfault_config/memfault_trace_reason_user_config.def
@@ -1,3 +1,4 @@
 /* Infuse-IoT specific Memfault traces */
 MEMFAULT_TRACE_REASON_DEFINE(secure_fault)
 MEMFAULT_TRACE_REASON_DEFINE(bt_ctlr_fault)
+MEMFAULT_TRACE_REASON_DEFINE(mpsl_fault)

--- a/include/infuse/reboot.h
+++ b/include/infuse/reboot.h
@@ -56,6 +56,8 @@ enum infuse_reboot_reason {
 	INFUSE_REBOOT_DFU = 135,
 	/** Bluetooth controller fault */
 	INFUSE_REBOOT_BT_CTLR_FAULT = 136,
+	/** Nordic MPSL fault */
+	INFUSE_REBOOT_MPSL_FAULT = 137,
 	/** Unknown reboot reason */
 	INFUSE_REBOOT_UNKNOWN = 255,
 } __packed;

--- a/kconfig/Kconfig.defaults.nrf
+++ b/kconfig/Kconfig.defaults.nrf
@@ -16,6 +16,10 @@ configdefault LOG_TIMESTAMP_64BIT
 configdefault CLOCK_CONTROL_NRF_HFINT_CALIBRATION
 	default y if !MPSL
 
+# Custom handling of MPSL assertion failures to enable logging
+configdefault MPSL_ASSERT_HANDLER
+	default y if BT_INFUSE_ASSERT_HANDLER
+
 configdefault NRF_CC3XX_PLATFORM
 	default y
 

--- a/subsys/bluetooth/assert_handler.c
+++ b/subsys/bluetooth/assert_handler.c
@@ -28,3 +28,18 @@ void bt_ctlr_assert_handle(char *file, uint32_t line)
 	/* Trigger a reboot */
 	infuse_reboot(INFUSE_REBOOT_BT_CTLR_FAULT, (uintptr_t)file, line);
 }
+
+#ifdef CONFIG_MPSL_ASSERT_HANDLER
+void mpsl_assert_handle(const char *const file, const uint32_t line)
+{
+#ifdef CONFIG_MEMFAULT
+	/* Store the assert information with Memfault if enabled */
+	MEMFAULT_TRACE_EVENT_WITH_LOG(mpsl_fault, "%s:%u", file, line);
+	/* Assert so we get a backtrace */
+	MEMFAULT_ASSERT_WITH_REASON(line, kMfltRebootReason_Assert);
+	/* If that didn't work for whatever reason, reboot manually */
+#endif /* CONFIG_MEMFAULT */
+	/* Trigger a reboot */
+	infuse_reboot(INFUSE_REBOOT_MPSL_FAULT, (uintptr_t)file, line);
+}
+#endif /* CONFIG_MPSL_ASSERT_HANDLER */


### PR DESCRIPTION
Add assertion handling for the Nordic MPSL library. This gives us better control over the logging and reboot behavior when MPSL asserts.